### PR TITLE
Making mustache.js work with Node.js

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -322,3 +322,10 @@ var Mustache = function() {
     }
   });
 }();
+
+/*
+  If using Node.js, export Mustache as a Node.js module.
+*/
+if (typeof(exports) != "undefined") {
+	module.exports = Mustache;
+}


### PR DESCRIPTION
Hi,

I've added a bit of code to the end of the _mustache.js_ file to export the `Mustache` object as a [Node](http://github.com/ry/node) module, if the user is using Mustache with Node. It checks if Node is being used by seeing if `exports` (defined by Node) has been defined or not.

This should encourage people to use Mustache with Node.

Thanks,
Chetan
