### PR TITLE
RSpec2 compatible Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,11 @@
 require 'rake'
-require 'spec/rake/spectask'
+require "rspec/core/rake_task" 
 
 task :default => :spec
 
-Spec::Rake::SpecTask.new(:spec) do |t|
-  #t.spec_opts = ['--options', "\"#{File.dirname(__FILE__)}/spec/spec.opts\""]
-  t.spec_files = FileList['test/*_spec.rb']
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  #spec.spec_opts = ['--options', "\"#{File.dirname(__FILE__)}/spec/spec.opts\""]
+  spec.pattern = 'test/*_spec.rb'
 end
 
 desc "Run all specs"

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,8 +1,0 @@
-{
-    "name": "mustache",
-    "author": "http://mustache.github.com/",
-    "description": "{{ mustache }} in JavaScript — Logic-less templates.",
-    "keywords": ["template"],
-    "version": "0.3.1-dev",
-    "main": "./mustache"
-}


### PR DESCRIPTION
For the most part as suggested in  [Upgrading your Rakefile from RSpec 1.3 to RSpec 2](http://pivotallabs.com/users/alex/blog/articles/1451-upgrading-your-rakefile-from-rspec-1-3-to-rspec-2).
This does most likely break RSpec 1.x compatibility.

I suspect that RSpec 2 is now more widely used as RSpec 1 (don't know of course); either way, one could consider separate branches. 
