### PR TITLE
Fix for Implicit Iterator Bug

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -264,7 +264,7 @@ var Mustache = function() {
       } else {
         var iterator = ".";
         if(this.pragmas["IMPLICIT-ITERATOR"]) {
-          iterator = this.pragmas["IMPLICIT-ITERATOR"].iterator;
+          iterator = this.pragmas["IMPLICIT-ITERATOR"].iterator || iterator;
         }
         var ctx = {};
         ctx[iterator] = _context;


### PR DESCRIPTION
Fixed bug where array is not rendered if implicit iterator is delcared without specifying the iterator.

Demonstration of the bug using example from the README.md:
http://jsfiddle.net/wtolson/KtwWj/

Demonstration of the fix:
http://jsfiddle.net/wtolson/BfbcF/
