### PR TITLE
Mustache Spec compliance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/spec"]
+	path = ext/spec
+	url = git://github.com/mustache/spec.git

--- a/test/compliance_spec.rb
+++ b/test/compliance_spec.rb
@@ -1,0 +1,53 @@
+require 'rubygems'
+require 'yaml'
+require 'json'
+
+YAML::add_builtin_type('code') do |_, value|
+  value['js'].tap do |func|
+    def func.to_json(_)
+      "function() { return #{self}; }"
+    end
+  end
+end
+
+__DIR__ = File.dirname(__FILE__)
+
+testnames = Dir.glob(__DIR__ + '/../ext/spec/specs/[^~]*.yml').map do |name|
+  File.basename name, '.yml'
+end
+
+def load_tests(dir, name)
+  file = File.join(dir, '..', 'ext', 'spec', 'specs', "#{name}.yml")
+  return YAML.load_file(file)['tests']
+end
+
+describe "Mustache Spec compliance" do
+  before(:all) do
+    @mustache = File.read(__DIR__ + "/../mustache.js")
+  end
+
+  testnames.each do |testname|
+    load_tests(__DIR__, testname).each do |test|
+      describe test['name'] do
+        it test['desc'] do
+          runner = <<-JS
+            #{@mustache}
+            print(Mustache.to_html(
+              #{test['template'].to_json},
+              #{test['data'].to_json},
+              #{test['partials'].to_json}
+            ));
+          JS
+
+          # #print appends a newline
+          run_js(runner).should == test['expected'] + "\n"
+        end
+      end
+    end
+  end
+
+  def run_js(js)
+    File.open("runner.js", 'w') {|f| f << js}
+    `js runner.js`
+  end
+end


### PR DESCRIPTION
Since Mustache implementations should strive to be template compatible, this change adds basic compliance testing against the formalized Mustache Spec.  This is currently set up against v1.1.2 of the spec, without support for the optional lambda module.