### PR TITLE
Poor performance when using large, complicated templates without newlines

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -104,7 +104,7 @@ var Mustache = function() {
 
       var that = this;
       // CSW - Added "+?" so it finds the tighest bound, not the widest
-      var regex = new RegExp(this.otag + "(\\^|\\#)\\s*(.+)\\s*" + this.ctag +
+      var regex = new RegExp(this.otag + "(\\^|\\#)\\s*(.+?)\\s*" + this.ctag +
               "\n*([\\s\\S]+?)" + this.otag + "\\/\\s*\\2\\s*" + this.ctag +
               "\\s*", "mg");
 


### PR DESCRIPTION
When using a large template that has no newlines, mustache takes a very long time to render a template (this is especially noticeable in FireFox)

I believe that the code that causes this is

```
  var regex = new RegExp(this.otag + "(\\^|\\#)\\s*(.+)\\s*" + this.ctag +
          "\n*([\\s\\S]+?)" + this.otag + "\\/\\s*\\2\\s*" + this.ctag +
          "\\s*", "mg");
```

... specifically the `.+` 
