### PR TITLE
Content truncation which ends with "..."

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -191,7 +191,7 @@ var Mustache = function() {
             break;
         }
 
-        if (truncate.shouldI && found) {
+        if (truncate.shouldI && found && found.length > truncate.after) {
             found = found.substring(0, truncate.after) + ' ...';
         }
 


### PR DESCRIPTION
In my current project it was necessary for me to truncate the strings within a template to a specific length and add the omnipresent "...".

I thought it would be cool if there is a notation for mustache tags to handle this problem. So I've implemented a small modification of the "render_tags" method. With this it is possible to shorten the string by defining the length within the tag:

{{thetag:20}} -> Shorten the "thetag" content to 20 chars and end up with " ...".

So maybe this is useful for somebody.

Regards,
André
