### PR TITLE
Reopen + Fix 14: Partials don't render when no data.

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -88,7 +88,7 @@ var Mustache = function() {
       if(!partials || partials[name] === undefined) {
         throw({message: "unknown_partial '" + name + "'"});
       }
-      if(typeof(context[name]) != "object") {
+      if(!context || typeof(context[name]) != "object") { //When no data, there is no context.
         return this.render(partials[name], context, partials, true);
       }
       return this.render(partials[name], context[name], partials, true);


### PR DESCRIPTION
Fixed check on context in render_partial, preventing attempt to read a property of undefined when rendering partials w/o data.

Addresses [Issue 14](https://github.com/janl/mustache.js/issues/14), which I ran into again for some reason.
