### PR TITLE
Fixed recursive lookup

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -215,11 +215,14 @@ var Mustache = function() {
       }
 
       var value;
-      if(is_kinda_truthy(context[name])) {
-        value = context[name];
-      } else if(is_kinda_truthy(this.context[name])) {
-        value = this.context[name];
+      while (context) {
+        if(is_kinda_truthy(context[name])) {
+          value = context[name];
+          break;
         }
+
+        context = context.__parent_context;
+      }
 
       if(typeof value === "function") {
         return value.apply(context);


### PR DESCRIPTION
Current "recursive" lookup in the context stack would only work for one level. I have quite complicated templates, and recursive lookup wasn't working. This should be slightly cleaner, with linked parent contexts. The clone is a bit ugly, maybe a real context stack would be the better way to go.
