### PR TITLE
Adds note about needing rspec to run rake commands. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ Or just install it as a RubyGem:
 ## Plugins for jQuery, Dojo, Yui, CommonJS
 
 This repository lets you build modules for [jQuery][], [Dojo][], [Yui][] and
-[CommonJS][] / [Node.js][] with the help of `rake`:
+[CommonJS][] / [Node.js][] with the help of `rake`. You may need to install
+rspec first by running `gem install rspec`.
 
 Run `rake jquery` to get a jQuery compatible plugin file in the
 `mustache-jquery/` directory.


### PR DESCRIPTION
I was getting the following error when running `rake commonjs`:

```
rake aborted!
no such file to load -- rspec/core/rake_task

(See full trace by running task with --trace)
```

This was with a default OS X Lion install. The issue was simply that
rspec was not installed, however, it may not be obvious at first.
