### PR TITLE
Back Slashes shouldn't be escaped in HTML

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -246,8 +246,7 @@ var Mustache = function() {
       s = String(s === null ? "" : s);
       return s.replace(/&(?!\w+;)|["'<>\\]/g, function(s) {
         switch(s) {
-        case "&": return "&amp;";
-        case "\\": return "\\\\";
+        case "&": return "&amp;";        
         case '"': return '&quot;';
         case "'": return '&#39;';
         case "<": return "&lt;";


### PR DESCRIPTION
Back Slashes don't cause any problem in html and shouldn't be escaped.  If you feel they should it should be &#92; instead of the javascript escape of \
