### PR TITLE
Allow context to be used as template. Maintain chainability.

### DIFF
--- a/mustache-jquery/jquery.mustache.js.tpl.post
+++ b/mustache-jquery/jquery.mustache.js.tpl.post
@@ -3,4 +3,12 @@
     return Mustache.to_html(template, view, partials);
   };
 
+  $.fn.mustache = function(view, partials){
+    return $(this).map(function(i, elm){
+        var template = $(elm).html().trim();
+        var output = $.mustache(template, view, partials);
+        return $(output).get();
+    });
+  };
+
 })(jQuery);


### PR DESCRIPTION
This changeset will allow the following:

In html:

``` html
<script id="content-tmpl" type="text/x-mustache-tmpl">
    <h1>{{name}}</h1>
</script>
<div id="content"></div>
```

In javascript:

``` javascript
var $tmpl = $('#content-tmpl').mustache({name: "Hello world"});
$('#content').append($tmpl);
```

Output:

``` html
<div id="content"><h1>Hello world</h1></div>
```
