### PR TITLE
Remove tab whitespace that was added during dot notation merge.

### DIFF
--- a/examples/dot_notation.js
+++ b/examples/dot_notation.js
@@ -1,18 +1,18 @@
 var dot_notation = {
-	name: "A Book",
-	authors: ["John Power", "Jamie Walsh"],
-	price:{
-	  value: 200,
-	  vat: function() {
-	    return this.value * 0.2;
-	  },
-		currency: {
-			symbol: '&euro;',
-			name: 'Euro'
-		}
-	},
-	availability:{
-		status: true,
-	  text: "In Stock"
-	}
+  name: "A Book",
+  authors: ["John Power", "Jamie Walsh"],
+  price:{
+    value: 200,
+    vat: function() {
+      return this.value * 0.2;
+    },
+    currency: {
+      symbol: '&euro;',
+      name: 'Euro'
+    }
+  },
+  availability:{
+    status: true,
+    text: "In Stock"
+  }
 };

--- a/mustache.js
+++ b/mustache.js
@@ -269,18 +269,18 @@ var Mustache = function() {
       }
 
       var value;
-			
-			// check for dot notation eg. foo.bar
-			if(name.match(/([a-z_]+)\./ig)){
-				value = is_kinda_truthy(this.walk_context(name, context));
-			}
-			else{
-				if(is_kinda_truthy(context[name])) {
-	        value = context[name];
-	      } else if(is_kinda_truthy(this.context[name])) {
-	        value = this.context[name];
-	      }
-			}
+      
+      // check for dot notation eg. foo.bar
+      if(name.match(/([a-z_]+)\./ig)){
+        value = is_kinda_truthy(this.walk_context(name, context));
+      }
+      else{
+        if(is_kinda_truthy(context[name])) {
+          value = context[name];
+        } else if(is_kinda_truthy(this.context[name])) {
+          value = this.context[name];
+        }
+      }
 
       if(typeof value === "function") {
         return value.apply(context);
@@ -292,21 +292,21 @@ var Mustache = function() {
       return "";
     },
 
-		walk_context: function(name, context){
-			var path = name.split('.');
-			// if the var doesn't exist in current context, check the top level context
-			var value_context = (context[path[0]] != undefined) ? context : this.context;
-			var value = value_context[path.shift()];
-			while(value != undefined && path.length > 0){
-				value_context = value;
-				value = value[path.shift()];
-			}
-			// if the value is a function, call it, binding the correct context
-			if(typeof value === "function") {
+    walk_context: function(name, context){
+      var path = name.split('.');
+      // if the var doesn't exist in current context, check the top level context
+      var value_context = (context[path[0]] != undefined) ? context : this.context;
+      var value = value_context[path.shift()];
+      while(value != undefined && path.length > 0){
+        value_context = value;
+        value = value[path.shift()];
+      }
+      // if the value is a function, call it, binding the correct context
+      if(typeof value === "function") {
         return value.apply(value_context);
       }
-			return value;
-		},
+      return value;
+    },
 
     // Utility methods
 


### PR DESCRIPTION
Hey Jan,

Here's a fix for the tabs that were added to the project as part of the dot notation merge. Each tab was painstakingly retired and replaced with 2 spaces over a matter of days.

Thanks for the 'stache.

Brandon
