### PR TITLE
Mustache.format

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -417,6 +417,18 @@ var Mustache = function() {
       if(!send_fun) {
         return renderer.buffer.join("\n");
       }
+    },
+    
+    format: function(template/*, args */) {
+      var args = Array.prototype.slice.call(arguments),
+          view = {};
+
+      args.shift();
+      for (var i = 0, n = args.length; i < n; ++i) {
+        view['' + i] = args[i];
+      }
+
+      return Mustache.to_html(template, view, {});
     }
   });
 }();


### PR DESCRIPTION
.format is syntactic sugar over the existing to_html function which adds a functionality similar to of the "String.format" from Java/C#. Basically, rather than take named tag keys, it uses numbered tag keys that correspond to the nth argument of the function:

```
Mustache.format('{{0}} is {{1}}.', 'Mustache', 'awesome'); // ==> 'Mustache is awesome.'
```

Of course, the full Mustache syntax is available:

```
Mustache.format('{{#0}}{{1}}{{/0}}.', isColorRed, 'red'); 
```

Look at this wiki article for more information: https://github.com/doodads/mustache.js/wiki/API-format

I find this bit of sugar very useful, so I thought I'd spread the love :)

I didn't know how to add unit tests since the test runner always runs against `to_html`. But if you let me know where/how to add them, I'll gladly do so.
