### PR TITLE
nuget spec for 0.5.x

### DIFF
--- a/mustache.js.nuspec
+++ b/mustache.js.nuspec
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>mustache.js</id>
+    <version>0.5.0-dev</version>
+    <authors>mustache.js Authors</authors>
+    <licenseUrl>https://github.com/janl/mustache.js/blob/master/LICENSE</licenseUrl>
+    <projectUrl>http://mustache.github.com/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Logic-less templates in JavaScript.</description>
+    <releaseNotes></releaseNotes>
+    <tags>mustache template templates javascript</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
per our discussion in https://github.com/janl/mustache.js/pull/170

This version number in this file should be updated when tagging a release.
