### PR TITLE
Strict escape

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -103,11 +103,26 @@ var Mustache = (typeof module !== "undefined" && module.exports) || {};
     });
   }
 
+  // OSWASP Guidlines: escape all non alphanumeric characters in ASCII space.
+  var HTML_ATTRIBUTE_CHARACTERS_EXPRESSION =
+      /[\x00-\x2F\x39-\x40\x5B-\x60\x7B-\xFF]/g;
+  function _escapeHTMLFanatic(string) {
+    return String(string).replace(HTML_ATTRIBUTE_CHARACTERS_EXPRESSION, function (s) {
+      if (escapeMap[s]) {
+        return escapeMap[s];
+      } else {
+        return "&#x" + ('00' + s.charCodeAt(0).toString(16)).slice(-2) + ";";
+      }
+    });
+  }
+
   function escapeHTML(string) {
     if (typeof (exports.escapeHTML) == 'function') {
       return exports.escapeHTML(string);
     } else if (exports.escapeHTML === 'strict') {
       return _escapeHTMLStrict(string);
+    } else if (exports.escapeHTML === 'fanatic') {
+      return _escapeHTMLFanatic(string);
     } else {
       return _escapeHTML(string);
     }


### PR DESCRIPTION
This Mustache interpreter avoids escaping the `&` character of substrings that look like HTML entities (see #19). AFAIK, other Mustaches are less forgiving and sometimes this behavior is desirable (if, say, the body of this message was provided as template data).

Ruby’s [mustache](https://github.com/defunkt/mustache) gives:

``` ruby
>> Mustache.to_html "{{amp}}", :amp => "&amp;"
=> "&amp;amp;"
```

This patch allows an escaping method to be injected (via exports) and provides strict and fanatic escaping methods. Discuss…
