### PR TITLE
Fix for inverted sections where value is an empty string or zero.

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -175,7 +175,12 @@ var Mustache = (typeof module !== "undefined" && module.exports) || {};
       // From the spec: inverted sections may render text once based on the
       // inverse value of the key. That is, they will be rendered if the key
       // doesn't exist, is false, or is an empty list.
-      if (value == null || value === false || (isArray(value) && value.length === 0)) {
+      // 
+      // "is false" in the spec should read "equates to false" for 
+      // clarification. Matching only === false results in a numeric 0 or an 
+      // empty string value not being matched by either a section or an 
+      // inverted section.
+      if (!value || (isArray(value) && value.length === 0)) {
         buffer += callback();
       }
     } else if (isArray(value)) {
@@ -289,6 +294,13 @@ var Mustache = (typeof module !== "undefined" && module.exports) || {};
     };
 
     var openInvertedSection = function (source) {
+        
+      // allow {{^}} else tag
+      if (trim(source) === "") {
+        source = sectionStack.length != 0 && sectionStack[sectionStack.length - 1].name;
+        closeSection(source);
+      }
+      
       openSection(source, true);
     };
 


### PR DESCRIPTION
This fixes Issue #186
A numeric 0 or an empty string will be matched by an inverted section as they equate to false.

I have also added support for use of an empty inverted section tag {{^}} as an else style tag for sections,
usage:
{{#section}}
    section
{{^}}
    inverted section
{{/section}}

This is equivalent of:
{{#section}}
    section
{{/section}}
{{^section}}
    inverted section
{{/section}}
