### PR TITLE
Strict escape II

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -86,11 +86,12 @@ var Mustache = (typeof module !== "undefined" && module.exports) || {};
     "<": "&lt;",
     ">": "&gt;",
     '"': '&quot;',
-    "'": '&#39;'
+    "'": '&#39;',
+    "/": '&#x2F;'
   };
 
   function escapeHTML(string) {
-    return String(string).replace(/&(?!\w+;)|[<>"']/g, function (s) {
+    return String(string).replace(/[&<>"'\/]/g, function (s) {
       return escapeMap[s] || s;
     });
   }

--- a/spec/_files/dot_notation.js
+++ b/spec/_files/dot_notation.js
@@ -7,8 +7,8 @@ var dot_notation = {
       return this.value * 0.2;
     },
     currency: {
-      symbol: '&euro;',
-      name: 'Euro'
+      symbol: '$',
+      name: 'USD'
     }
   },
   availability:{

--- a/spec/_files/dot_notation.txt
+++ b/spec/_files/dot_notation.txt
@@ -1,8 +1,8 @@
 <!-- exciting part -->
 <h1>A Book</h1>
 <p>Authors: <ul><li>John Power</li><li>Jamie Walsh</li></ul></p>
-<p>Price: &euro;200 Euro <b>In Stock</b></p>
-<p>VAT: &euro;40</p>
+<p>Price: $200 USD <b>In Stock</b></p>
+<p>VAT: $40</p>
 <!-- boring part -->
 <h2>Test truthy false values:</h2>
 <p>Zero: 0</p>

--- a/spec/_files/escaped.js
+++ b/spec/_files/escaped.js
@@ -2,5 +2,5 @@ var escaped = {
   title: function() {
     return "Bear > Shark";
   },
-  entities: "&quot;"
+  entities: "&quot; \"'<>/"
 };

--- a/spec/_files/escaped.txt
+++ b/spec/_files/escaped.txt
@@ -1,2 +1,2 @@
 <h1>Bear &gt; Shark</h1>
-But not &quot;.
+But not &amp;quot; &quot;&#39;&lt;&gt;&#x2F;.


### PR DESCRIPTION
This replaces the soft escaping (`&amp;` -> `&amp;`) with strict escaping (`&amp;` -> `&amp;amp;`). This new behavior matches that of Ruby and other Mustache implementations.

Other points:
- `dot_notation` currency is changed to use an ASCII character, since the JS interpreters did not appreciate unicode.
- Forward slash is added to escape list c/o OWASP recommendations.

_Note:_ This does change behavior in an arguably non-backward compatible way.

See also #183.
