### PR TITLE
Treat an empty string as falsey in inverted sections.

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -175,7 +175,7 @@ var Mustache = (typeof module !== "undefined" && module.exports) || {};
       // From the spec: inverted sections may render text once based on the
       // inverse value of the key. That is, they will be rendered if the key
       // doesn't exist, is false, or is an empty list.
-      if (value == null || value === false || (isArray(value) && value.length === 0)) {
+      if (!value || (isArray(value) && value.length === 0)) {
         buffer += callback();
       }
     } else if (isArray(value)) {

--- a/spec/_files/inverted_section.js
+++ b/spec/_files/inverted_section.js
@@ -1,3 +1,4 @@
 var inverted_section =  {
-  "repos": []
+  "repos": [],
+  "empty_string": ""
 };

--- a/spec/_files/inverted_section.mustache
+++ b/spec/_files/inverted_section.mustache
@@ -1,3 +1,4 @@
 {{#repos}}<b>{{name}}</b>{{/repos}}
 {{^repos}}No repos :({{/repos}}
 {{^nothin}}Hello!{{/nothin}}
+{{^empty_string}}Empty string should be falsey{{/empty_string}}

--- a/spec/_files/inverted_section.txt
+++ b/spec/_files/inverted_section.txt
@@ -1,3 +1,4 @@
 
 No repos :(
 Hello!
+Empty string should be falsey


### PR DESCRIPTION
Treat an empty string (or for that matter, any value that evaluates to false) as falsey in inverted sections.

Per the spec (https://github.com/mustache/spec/issues/28), a value is falsey if the host language treats it as falsey. JavaScript treats an empty string as falsey.

Fixes issue #186 (https://github.com/janl/mustache.js/issues/186)
