### PR TITLE
Fixed a variable error in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ or is an empty list, the block will not be rendered.
 Template:
 
     Shown.
-    {{#nothin}}
+    {{#person}}
     Never shown!
-    {{/nothin}}
+    {{/person}}
 
 View:
 


### PR DESCRIPTION
Changed "nothin" => "person" to make the documentation match the output.
