### PR TITLE
Fix for null data for a section

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -485,7 +485,7 @@ var Mustache = (typeof module !== "undefined" && module.exports) || {};
 
       if (value) {
         for (var i = 0, len = value.length; i < len; ++i) {
-          chr = value[i];
+          chr = value.charAt(i);
 
           if (isWhitespace(chr)) {
             spaces.push(tokens.length);


### PR DESCRIPTION
"context.view" is null and "context.view[name]" caused an error when data for a section is null.

Below is a test case that causes the error.

``` javascript
var data = {name: 'foo', friends: null};
var tmpl = "{{name}}'s friends: {{#friends}}{{name}}, {{/friends}}";
```
