### PR TITLE
add current context only search for mustache

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -170,11 +170,18 @@ var Mustache = (typeof module !== "undefined" && module.exports) || {};
         value = this.view;
       } else {
         var context = this;
-
+        //support current context only search: ".children"
+        var noBubble = name && name[0] === ".";
+        
         while (context) {
-          if (name.indexOf(".") > 0) {
+          if (name.indexOf(".") > -1) {
             var names = name.split("."), i = 0;
-
+            
+            if(noBubble)
+            {
+              names.shift();
+            }
+            
             value = context.view;
 
             while (value && i < names.length) {
@@ -184,7 +191,7 @@ var Mustache = (typeof module !== "undefined" && module.exports) || {};
             value = context.view[name];
           }
 
-          if (value != null) {
+          if (value != null || noBubble) {
             break;
           }
 


### PR DESCRIPTION
This feature solves my project problem about using recursive template.Both parent node and child nodes has same property name ,when child node does not have that property(or null value),template will search parent property,this cause a recursive reference problem. Use ".children" to force search only with current context,not continue searching parent context.
