### PR TITLE
Allow Compiling of Tokens without Template

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -345,7 +345,7 @@ var Mustache;
 
         switch (token[0]) {
         case "#":
-          sectionText = template.slice.apply(template, sectionBounds(token));
+          sectionText = template == null ? null : template.slice.apply(template, sectionBounds(token));
           buffer += writer._section(token[1], context, sectionText, subRender(i, token[4], template));
           break;
         case "^":


### PR DESCRIPTION
The idea of parsing into tokens is to not need the templates.  This allows you to render without a template.  It will perform as expected as long as you don't use functions in your data; function tags will `null` instead of the text in the tags that they're expecting.
