### PR TITLE
Mustache fails if no template is passed in.

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -603,6 +603,7 @@ var Mustache;
    * default writer.
    */
   exports.render = function (template, view, partials) {
+    if(template === undefined) return "";
     return _writer.render(template, view, partials);
   };
 


### PR DESCRIPTION
Right now if `Mustache.render` is called without passing a template in, an error is thrown.

![](http://cl.ly/KBYI/Screen%20Shot%202012-10-16%20at%2011.45.09%20AM.png)

It would be more graceful to simply return an empty string if a template isn't passed in.
