### PR TITLE
jQuery wrapper: use jQuery.trim() instead of String.prototype.trim()

### DIFF
--- a/wrappers/jquery/mustache.js.post
+++ b/wrappers/jquery/mustache.js.post
@@ -1,11 +1,10 @@
-
   $.mustache = function (template, view, partials) {
     return Mustache.render(template, view, partials);
   };
 
   $.fn.mustache = function (view, partials) {
     return $(this).map(function (i, elm) {
-      var template = $(elm).html().trim();
+      var template = $.trim($(elm).html());
       var output = $.mustache(template, view, partials);
       return $(output).get();
     });


### PR DESCRIPTION
Switched from String.prototype.trim() to jQuery.trim() for IE8 and below support. This fixes issue #268
