### PR TITLE
Number zero is not false

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -271,7 +271,7 @@
 
         // Use JavaScript's definition of falsy. Include empty arrays.
         // See https://github.com/janl/mustache.js/issues/186
-        if (!value || (isArray(value) && value.length === 0)) {
+        if (value!==0 && !value || (isArray(value) && value.length === 0)) {
           buffer += renderTokens(token[4], writer, context, template);
         }
 

--- a/test/_files/falsy.txt
+++ b/test/_files/falsy.txt
@@ -3,7 +3,7 @@ inverted empty string
 
 inverted empty array
 zero
-inverted zero
+
 
 inverted null
 


### PR DESCRIPTION
When displaying numbers, don't use zero as a false value so it can be printed
