### PR TITLE
fix:Object doesnt support this property or method

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -216,7 +216,9 @@
           self._loadPartial = partials;
         } else {
           for (var name in partials) {
-            self.compilePartial(name, partials[name]);
+            if (partials.hasOwnProperty(name)) {
+              self.compilePartial(name, partials[name]);
+            }
           }
         }
       }


### PR DESCRIPTION
partials.hasOwnProperty(name) ensures that we are iterating only @ the right scope of the partials container fixing errors caused by the prototypal chain.
