### PR TITLE
Added support for compile methods in jQuery

### DIFF
--- a/wrappers/jquery/mustache.js.post
+++ b/wrappers/jquery/mustache.js.post
@@ -1,13 +1,32 @@
   $.mustache = function (template, view, partials) {
     return Mustache.render(template, view, partials);
   };
-
-  $.fn.mustache = function (view, partials) {
-    return $(this).map(function (i, elm) {
-      var template = $.trim($(elm).html());
-      var output = $.mustache(template, view, partials);
-      return $(output).get();
-    });
+  var methods = {
+    init: function(view, partials) {
+      return $(this).map(function (i, elm) {
+        var template = $.trim($(elm).html());
+        var output = $.mustache(template, view, partials);
+        return $(output).get();
+      });
+    },
+    //var compiledTemplate = $('#template').mustache('compile');
+    compile: function() {
+      var template = $.trim(this.html());
+      return Mustache.compile(template);
+    },
+    //$('#template').mustache('compilePartial', 'partial-name');
+    compilePartial: function(name) {
+      var template = $.trim(this.html());
+      Mustache.compilePartial(name, template);
+      return this;
+    }
+  };
+  $.fn.mustache = function (method) {
+    if ( methods[method] ) {
+      return methods[ method ].apply( this, Array.prototype.slice.call( arguments, 1 ));
+    } else if ( typeof method === 'object' || ! method ) {
+      return methods.init.apply( this, arguments );
+    }
   };
 
 })(jQuery);


### PR DESCRIPTION
I think this would be useful not only for me...
Usage:

``` js
var compiledTemplate = $('#template').mustache('compile');
```

and

``` js
$('#template').mustache('compilePartial', 'partial-name');
```
