### PR TITLE
Allow for key references

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -301,7 +301,9 @@
           value = context.lookup(tokenValue.replace(refRe, ref));
         }
 
-        if (value != null && value != undefined) buffer += value;
+        if (value != null && value != undefined) {
+          buffer += exports.escape(value);
+        }
         break;
       case 'text':
         buffer += tokenValue;


### PR DESCRIPTION
We've been using this at Nodejitsu, and thought it might be useful `mustache.js` itself. Lets consider that you have a template the requires dynamic keynames like like:

```
foo.{{ refs.0 }}.foo: {{ foo.{{ refs.0 }}.foo }}
foo.{{ refs.1 }}: {{ foo.{{ refs.1 }} }}
{{ refs.2 }}: {{ {{ refs.2 }} }}
```

With a view:

``` js
  {
    "foo": {
      "first": { "foo": "bar" }
      "second": "second-value"
    },
    "third": "third-value"
    "refs": [
      "first",
      "second",
      "third"
    ]
  }
```

This would render:

```
  foo.first.foo: bar
  foo.second: second-value
  third: third-value
```

Thoughts? If you're interested in this I'll work up some tests.
