### PR TITLE
fix for environments with changes in Object.prototype

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -205,7 +205,9 @@
           self._loadPartial = partials;
         } else {
           for (var name in partials) {
-            self.compilePartial(name, partials[name]);
+            if (partials.hasOwnProperty(name)) {
+              self.compilePartial(name, partials[name]);
+            }
           }
         }
       }


### PR DESCRIPTION
Although it's not recommended to, but it's allowed to augment Object.prototype with more properties and methods. Using hasOwnProperty enables Mustache to work with no changes in those environments.