### PR TITLE
Add a way to acceed to loop data

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -238,6 +238,17 @@
 
         if (typeof value === 'object') {
           if (isArray(value)) {
+            context = context.push({
+              '@index':function(){
+                return j+1;
+              },
+              '@arrayindex':function(){
+                return j;
+              },
+              '@length':function(){
+                return jlen;
+              }
+            });
             for (var j = 0, jlen = value.length; j < jlen; ++j) {
               buffer += renderTokens(token[4], writer, context.push(value[j]), template);
             }


### PR DESCRIPTION
when using block {{#anArray}} {{/anArray}}
You may accedd to loop datas with @index @arrayindex and @length
{{@index}} / {{@length}}
will output
1 / 12
2 / 12
3 / 12
...
@arrayindex start at 0 instead of 1

Maybe there is a better way to do this, but something is really missing on this point
