### PR TITLE
Allow interpolation to be usefull

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -140,8 +140,8 @@
 
         while (context) {
           if (name.indexOf('.') > 0) {
-            value = context.view;
             var names = name.split('.'), i = 0;
+            value = this.lookup(names.shift());
             while (value && i < names.length) {
               value = value[names[i++]];
             }


### PR DESCRIPTION
With this modification when using
{{#foo.bar}}
foo might be a function or be in an upper context than the current one, and it will return what is expected in more case
