### PR TITLE
Fixed bug where nested partials would output [Object object] for empty strings.

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -116,7 +116,7 @@
   };
 
   function Context(view, parent) {
-    this.view = view || {};
+    this.view = view === undefined ? {} : view;
     this.parent = parent;
     this._cache = {};
   }


### PR DESCRIPTION
When I used a nested partial template with an array that contained an empty string, Mustache would incorrectly output [Object object] in place of that string. I found that the bug was due to conditional statement that replaced all "falsy" values with an object, so I replaced it with an explicit check for undefined values.
