### PR TITLE
FIX Mustache AMD and global identifier definition

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -6,17 +6,26 @@
 /*global define: false*/
 
 (function (root, factory) {
+  // Define a local copy of Mustache.
+  var Mustache = {};
+  
+  // Build Mustache
+  factory(Mustache);
+
   if (typeof exports === "object" && exports) {
-    factory(exports); // CommonJS
+    module.exports = Mustache; // CommonJS
   } else {
-    var mustache = {};
-    factory(mustache);
     if (typeof define === "function" && define.amd) {
-      define(mustache); // AMD
-    } else {
-      root.Mustache = mustache; // <script>
+      define( "mustache", Mustache ); // AMD
     }
   }
+
+  // If there is a window object, that at least has a document property,
+  // define the Mustache identifier
+  if ( typeof root === "object" && typeof root.document === "object" ) {
+    root.Mustache = Mustache;
+  }
+
 }(this, function (mustache) {
 
   var whiteRe = /\s*/;


### PR DESCRIPTION
This pull request tries to solve compatibility errors that occur when RequireJS (or CommonJS) is loaded on a page where mustache.js is also loaded via a separate HTML script tag (by a third party plugin for example).

The fix is based on how jQuery implements AMD and defines the jQuery and $ global identifiers:

``` javascript
// Define a local copy of jQuery
var jQuery = function( selector, context ) {
    ...
};

...

if ( typeof module === "object" && module && typeof module.exports === "object" ) {
    // Expose jQuery as module.exports in loaders that implement the Node
    // module pattern (including browserify). Do not create the global, since
    // the user will be storing it themselves locally, and globals are frowned
    // upon in the Node module world.
    module.exports = jQuery;
} else {
    // Register as a named AMD module, since jQuery can be concatenated with other
    // files that may use define, but not via a proper concatenation script that
    // understands anonymous AMD modules. A named AMD is safest and most robust
    // way to register. Lowercase jquery is used because AMD module names are
    // derived from file names, and jQuery is normally delivered in a lowercase
    // file name. Do this after creating the global so that if an AMD module wants
    // to call noConflict to hide this version of jQuery, it will work.
    if ( typeof define === "function" && define.amd ) {
        define( "jquery", [], function () { return jQuery; } );
    }
}

// If there is a window object, that at least has a document property,
// define jQuery and $ identifiers
if ( typeof window === "object" && typeof window.document === "object" ) {
    window.jQuery = window.$ = jQuery;
}
```
