### PR TITLE
When rendering partials, pass the partial template instead of the original template.

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -496,8 +496,9 @@
         break;
       case '>':
         if (!partials) continue;
-        value = this.parse(isFunction(partials) ? partials(token[1]) : partials[token[1]]);
-        if (value != null) buffer += this.renderTokens(value, context, partials, originalTemplate);
+        var partialTemplate = isFunction(partials) ? partials(token[1]) : partials[token[1]];
+        value = this.parse(partialTemplate);
+        if (value != null) buffer += this.renderTokens(value, context, partials, partialTemplate);
         break;
       case '&':
         value = context.lookup(token[1]);

--- a/test/_files/section_functions_in_partials.js
+++ b/test/_files/section_functions_in_partials.js
@@ -1,0 +1,7 @@
+({
+  bold: function(){
+    return function(text, render) {
+      return "<b>" + render(text) + "</b>";
+    }
+  }
+})

--- a/test/_files/section_functions_in_partials.mustache
+++ b/test/_files/section_functions_in_partials.mustache
@@ -1,0 +1,3 @@
+{{> partial}}
+
+<p>some more text</p>

--- a/test/_files/section_functions_in_partials.partial
+++ b/test/_files/section_functions_in_partials.partial
@@ -1,0 +1,1 @@
+{{#bold}}Hello There{{/bold}}

--- a/test/_files/section_functions_in_partials.txt
+++ b/test/_files/section_functions_in_partials.txt
@@ -1,0 +1,3 @@
+<b>Hello There</b>
+
+<p>some more text</p>


### PR DESCRIPTION
Detected this bug while investigating why Punch's block helpers stopped working after upgrading mustache.js to 0.8.0 from 0.7.3 (https://github.com/laktek/punch/issues/106).
