### PR TITLE
Add a filter for emitting JS data

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -73,6 +73,10 @@
           s += "\\'";
         } else if (c == '\\') {
           s += '\\\\';
+        } else if (c == '<') {
+          s += '\\x3c';
+        } else if (c == '/') {
+          s += '\\x2f';
         } else if (n < 32 || n > 122) {
           var code = n.toString(16);
 

--- a/test/_files/js_escape.js
+++ b/test/_files/js_escape.js
@@ -1,4 +1,5 @@
 ({ string: "This is my\u2028string\"'."
+, breaker: "This is my string with a </script> tag."
 , array: ["abc\u2028", 1.1, [2, 3, true], "z"]
 , object: {"key\u2028": false, "otherkey": true, "finalkey": 3}
 , nil: null

--- a/test/_files/js_escape.mustache
+++ b/test/_files/js_escape.mustache
@@ -1,5 +1,6 @@
 <script>
   var s = {{$string}},
+      b = {{$breaker}},
       a = {{$array}},
       o = {{$object}},
       n = {{$nil}},

--- a/test/_files/js_escape.txt
+++ b/test/_files/js_escape.txt
@@ -1,5 +1,6 @@
 <script>
   var s = 'This is my\u2028string"\'.',
+      b = 'This is my string with a \x3c\x2fscript> tag.',
       a = ['abc\u2028',1.1,[2,3,true],'z'],
       o = {'key\u2028':false,'otherkey':true,'finalkey':3},
       n = null,


### PR DESCRIPTION
In our application, we sometimes need to embed Javascript variables:

```
<p>Hello, {{name}}.</p>
<script>
  var x = {{{x}}};
</script>
```

However, in order to do this, we've had to call `JSON.stringify` from the calling code before rendering the template:

```
mustache.render('...', {
  name: 'thomas',
  x: JSON.stringify([1, 2, 'asdf']),
});
```

It's easy to forget which variables must be stringified, and which shouldn't be.  This is because mustache is designed to emit HTML.  However, JS is such an integral part of HTML, it deserves its own emitting mode.

Additionally, JSON.stringify actually can't even be relied upon to emit correct JS (http://timelessrepo.com/json-isnt-a-javascript-subset).  The string `JSON.stringify('\u2028')`, for instance, is an invalid JS string, because it contains a line separator.

This commit implements a new filter which will emit JS.  The above template would be written:

```
<p>Hello, {{name}}.</p>
<script>
  var x = {{js&x}};
</script>
```

The `js&` tag was chosen arbitrarily.  Any other tag would work just as well.
