### PR TITLE
Fixes AMD registration, volo package.json entry

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -9,9 +9,9 @@
   if (typeof exports === "object" && exports) {
     factory(exports); // CommonJS
   } else if (typeof define === "function" && define.amd) {
-    define(factory({})); // AMD
+    define(['exports'], factory); // AMD
   } else {
-    global.Mustache = factory({}); // <script>
+    factory(global.Mustache = {}); // <script>
   }
 }(this, function (mustache) {
 
@@ -39,7 +39,7 @@
   function isWhitespace(string) {
     return !testRegExp(nonSpaceRe, string);
   }
-  
+
   var entityMap = {
     "&": "&amp;",
     "<": "&lt;",
@@ -574,7 +574,5 @@
   mustache.Scanner = Scanner;
   mustache.Context = Context;
   mustache.Writer = Writer;
-
-  return mustache;
 
 }));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "mocha": "1.5.0"
   },
   "volo": {
-    "url": "https://raw.github.com/janl/mustache.js/0.7.3/mustache.js"
+    "url": "https://raw.github.com/janl/mustache.js/{version}/mustache.js"
   },
   "scripts": {
     "test": "mocha test"


### PR DESCRIPTION
This change allows the AMD define signature to match what common AMD optimizers use to find define calls that need naming. Also updates the volo package.json entry so that the correct version of mustache can be fetched properly.

I got a report that the latest master was not optimizing correctly in the r.js optimizer, and traced the issue to the change in the define() signature. 

The 'exports' dependency is [one of the special AMD dependencies](https://github.com/jrburke/requirejs/wiki/Differences-between-the-simplified-CommonJS-wrapper-and-standard-AMD-define#magic) that gives the same desired outcome as the CommonJS pathway, and it means a return in the factory is no longer needed.

While pulling mustache via volo, also noticed the package.json URL needed to be updated to be more generic.

If you prefer these to be two different pull requests, just let me know and I will redo it.
