### PR TITLE
Section with "length" property

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -368,7 +368,7 @@
 
           while (value != null && index < names.length)
             value = value[names[index++]];
-        } else {
+        } else if (typeof context.view == 'object') {
           value = context.view[name];
         }
 

--- a/test/_files/bug_length_property.js
+++ b/test/_files/bug_length_property.js
@@ -1,0 +1,3 @@
+({
+    length: 'hello'
+})

--- a/test/_files/bug_length_property.mustache
+++ b/test/_files/bug_length_property.mustache
@@ -1,0 +1,1 @@
+{{#length}}The length variable is: {{length}}{{/length}}

--- a/test/_files/bug_length_property.txt
+++ b/test/_files/bug_length_property.txt
@@ -1,0 +1,1 @@
+The length variable is: hello


### PR DESCRIPTION
When a section is named `length`, it breaks if it has a String value, as the `lookup` function traverses the context, and erroneously finds a `length` property on the String.

The fix restricts `lookup` to only traverse objects (and arrays) for the requested property.
