### PR TITLE
Drop `#` from `tag` comment

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -94,7 +94,7 @@
     var nonSpace = false;  // Is there a non-space char on the current line?
 
     // Strips all whitespace tokens array for the current line
-    // if there was a {{#tag}} on it and otherwise only space.
+    // if there was a {{tag}} on it and otherwise only space.
     function stripSpace() {
       if (hasTag && !nonSpace) {
         while (spaces.length)


### PR DESCRIPTION
Jekyll, the static site generator, is planning to move to the newest version of Liquid, Liquid 3, running in `strict` mode.

It seems that Liquid really hates the fact that there's a non-alphanumeric tag in mustache.js. It interprets the `{{#tag}}` comment badly. This PR removes the `#` from the comment. 