### PR TITLE
Run jshint before tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
   "eqnull": true,
-  "evil": true
+  "evil": true,
+  "unused": true
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - 0.8
   - '0.10'
   - 0.11
+before_install:
+  - "test $TRAVIS_NODE_VERSION = '0.6' && npm install -g npm@1.3.26 || npm install -g npm"
 matrix:
   allow_failures:
     - node_js: 0.11

--- a/README.md
+++ b/README.md
@@ -490,6 +490,14 @@ Then, you can run the test with:
 
     $ TEST=mytest npm run test-render
 
+### Troubleshooting
+
+#### npm install fails
+
+Ensure to have a recent version of npm installed. While developing this project requires npm with support for `^` version ranges.
+
+    $ npm install -g npm
+
 ## Thanks
 
 mustache.js wouldn't kick ass if it weren't for these fine souls:

--- a/mustache.js
+++ b/mustache.js
@@ -507,7 +507,7 @@
       return this.renderTokens(token[4], context, partials, originalTemplate);
   };
 
-  Writer.prototype._renderPartial = function(token, context, partials, originalTemplate) {
+  Writer.prototype._renderPartial = function(token, context, partials) {
     if (!partials) return;
 
     var value = isFunction(partials) ? partials(token[1]) : partials[token[1]];

--- a/package.json
+++ b/package.json
@@ -17,12 +17,17 @@
   "volo": {
     "url": "https://raw.github.com/janl/mustache.js/{version}/mustache.js"
   },
+  "engines": {
+    "npm": ">=1.4.0"
+  },
   "scripts": {
+    "pretest": "jshint mustache.js",
     "test": "mocha --reporter spec",
     "test-render": "mocha  --reporter spec test/render-test"
   },
   "devDependencies": {
-    "mocha": "2.0.1"
+    "jshint": "~2.4.4",
+    "mocha": "~2.1.0"
   },
   "spm": {
     "main": "mustache.js",


### PR DESCRIPTION
Hi,
`jshint` should also be able to break the build, not just broken tests. Atm `jshint` run as a part of the `Rakefile`, that's a bit too late. It forces the maintainer doing a new mustache.js release to clean up codestyle violations. IMO it should be the PR developer's responsibility to clean up the code.

This PR includes a good example; clumpsy me left an unused variable in my previous refactoring PR #414. That might have broken the release script and someone else would have to fix my mistake. I would ofcourse have fixed it immediately if the travis run would have failed.