### PR TITLE
Browser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ yui3
 qooxdoo.mustache.js
 
 npm-debug.log
+
+test/render-test-browser.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ node_js:
   - 0.12
 before_install:
   - "test $TRAVIS_NODE_VERSION = '0.6' && npm install -g npm@1.3.26 || npm install -g npm"
+script:
+  - npm test
+  - npm run test-browser
 matrix:
   allow_failures:
     - node_js: 0.11
+env:
+  global:
+    - secure: TKDF1BgAR3S1bqFvikN6O3nbcLk20PDkL6QUVS6IkqQNtL1wXK4+2+GKcvJzOjCZg4OnXAFFtF/rfh9bcNlrGtWCG9CFkuGjUM7iONSQJr0kvCn7jris2jGGBupoPkX7MKlxaqrg6bmbp1QgA42/Hu4AlsNPCBiuFjpvL67VSqg=
+    - secure: sOyIxcOBaiFFUoL0+NcHPRVZm2LnG8u6qOzkrr4gSHil/qd8t91KOdJYVkZHWanI3R+T9sv8yDeZGTBz3QS993Wp0S0D3BjB2LKu8e7QFlMIms8dBQD6IR868qF6H22Qyaz5SNVwPuWVsEs8p92dc2C2xw9AvGSP3kpNe8aMjCA=

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,16 @@
+ui: mocha-bdd
+browsers:
+  - name: chrome
+    version: latest
+  - name: firefox
+    version: latest
+  - name: safari
+    version: 6..latest
+  - name: opera
+    version: 11..latest
+  - name: ie
+    version: 8..latest
+  - name: iphone
+    version: 6.0..latest
+  - name: android
+    version: 4.0..latest

--- a/README.md
+++ b/README.md
@@ -522,6 +522,14 @@ Then, you can run the test with:
 
     $ TEST=mytest npm run test-render
 
+### Browser tests
+
+Browser tests are not included in `npm test` as they run for too long, although they are runned automatically on Travis upon commit. Run browser tests locally in any browser:
+
+    $ npm run test-browser-local
+
+then point your browser to `http://localhost:8080/__zuul`
+
 ### Troubleshooting
 
 #### npm install fails

--- a/package.json
+++ b/package.json
@@ -32,12 +32,16 @@
   },
   "scripts": {
     "pretest": "eslint mustache.js",
-    "test": "mocha --reporter spec",
-    "test-render": "mocha  --reporter spec test/render-test"
+    "test": "mocha --reporter spec test/*-test.js",
+    "test-render": "mocha  --reporter spec test/render-test",
+    "pre-test-browser": "node test/create-browser-suite.js",
+    "test-browser": "npm run pre-test-browser && zuul -- test/context-test.js test/parse-test.js test/scanner-test.js test/render-test-browser.js",
+    "test-browser-local": "npm run pre-test-browser && zuul --local 8080 -- test/context-test.js test/scanner-test.js test/parse-test.js test/render-test-browser.js"
   },
   "devDependencies": {
     "eslint": "^0.20.0",
-    "mocha": "~2.1.0"
+    "mocha": "~2.1.0",
+    "zuul": "^2.1.1"
   },
   "spm": {
     "main": "mustache.js",

--- a/test/create-browser-suite.js
+++ b/test/create-browser-suite.js
@@ -1,0 +1,14 @@
+require('./helper');
+
+var renderHelper = require('./render-helper');
+
+var fs = require('fs');
+var path = require('path');
+
+var _testsTemplate = path.join(__dirname, 'render-test-browser-tmpl.mustache');
+var _templateContent = fs.readFileSync(_testsTemplate).toString();
+
+var tests = renderHelper.getTests();
+var content = Mustache.render(_templateContent, JSON.stringify(tests));
+
+fs.writeFileSync(path.join(__dirname, 'render-test-browser.js'), content);

--- a/test/render-helper.js
+++ b/test/render-helper.js
@@ -1,0 +1,55 @@
+var fs = require('fs');
+var path = require('path');
+
+var _files = path.join(__dirname, '_files');
+
+function getContents(testName, ext) {
+  try {
+    return fs.readFileSync(path.join(_files, testName + '.' + ext), 'utf8');
+  } catch (ex) {
+    return null;
+  }
+}
+
+function getView(testName) {
+  var view = getContents(testName, 'js');
+  if (!view) throw new Error('Cannot find view for test "' + testName + '"');
+  return view;
+}
+
+function getPartial(testName) {
+  try {
+    return getContents(testName, 'partial');
+  } catch (error) {
+    // No big deal. Not all tests need to test partial support.
+  }
+}
+
+// You can put the name of a specific test to run in the TEST environment
+// variable (e.g. TEST=backslashes vows test/render-test.js)
+var testToRun = process.env.TEST;
+
+var testNames;
+if (testToRun) {
+  testNames = [testToRun];
+} else {
+  testNames = fs.readdirSync(_files).filter(function (file) {
+    return (/\.js$/).test(file);
+  }).map(function (file) {
+    return path.basename(file).replace(/\.js$/, '');
+  });
+}
+
+function getTest(testName) {
+  return {
+    name: testName,
+    view: getView(testName),
+    template: getContents(testName, 'mustache'),
+    partial: getPartial(testName),
+    expect: getContents(testName, 'txt')
+  };
+}
+
+exports.getTests = function getTests() {
+  return testNames.map(getTest);
+};

--- a/test/render-test-browser-tmpl.mustache
+++ b/test/render-test-browser-tmpl.mustache
@@ -1,0 +1,30 @@
+require('./helper');
+
+describe('Mustache.render', function () {
+  beforeEach(function () {
+    Mustache.clearCache();
+  });
+
+  var i;
+  var tests = {{{.}}};
+
+  for (i = 0; i < tests.length; i++) {
+
+    (function indexClosure(test) {
+        var view = eval(test.view);
+
+        it('knows how to render ' + test.name, function () {
+
+          var output;
+          if (test.partial) {
+            output = Mustache.render(test.template, view, { partial: test.partial });
+          } else {
+            output = Mustache.render(test.template, view);
+          }
+
+          assert.equal(output, test.expect);
+        });
+    })(tests[i]);
+
+  }
+});

--- a/test/render-test.js
+++ b/test/render-test.js
@@ -1,72 +1,27 @@
 require('./helper');
 
-var fs = require('fs');
-var path = require('path');
-var _files = path.join(__dirname, '_files');
+var renderHelper = require('./render-helper');
 
-function getContents(testName, ext) {
-  try {
-    return fs.readFileSync(path.join(_files, testName + '.' + ext), 'utf8');
-  } catch (ex) {
-    return null;
-  }
-}
-
-function getView(testName) {
-  var view = getContents(testName, 'js');
-  if (!view) throw new Error('Cannot find view for test "' + testName + '"');
-  return eval(view);
-}
-
-function getPartial(testName) {
-  try {
-    return getContents(testName, 'partial');
-  } catch (error) {
-    // No big deal. Not all tests need to test partial support.
-  }
-}
-
-function getTest(testName) {
-  var test = {};
-  test.view = getView(testName);
-  test.template = getContents(testName, 'mustache');
-  test.partial = getPartial(testName);
-  test.expect = getContents(testName, 'txt');
-  return test;
-}
-
-// You can put the name of a specific test to run in the TEST environment
-// variable (e.g. TEST=backslashes vows test/render-test.js)
-var testToRun = process.env.TEST;
-
-var testNames;
-if (testToRun) {
-  testNames = [testToRun];
-} else {
-  testNames = fs.readdirSync(_files).filter(function (file) {
-    return (/\.js$/).test(file);
-  }).map(function (file) {
-    return path.basename(file).replace(/\.js$/, '');
-  });
-}
+var tests = renderHelper.getTests();
 
 describe('Mustache.render', function () {
   beforeEach(function () {
     Mustache.clearCache();
   });
 
-  testNames.forEach(function (testName) {
-    var test = getTest(testName);
+  tests.forEach(function (test) {
+    var view = eval(test.view);
 
-    it('knows how to render ' + testName, function () {
+    it('knows how to render ' + test.name, function () {
       var output;
       if (test.partial) {
-        output = Mustache.render(test.template, test.view, { partial: test.partial });
+        output = Mustache.render(test.template, view, { partial: test.partial });
       } else {
-        output = Mustache.render(test.template, test.view);
+        output = Mustache.render(test.template, view);
       }
 
       assert.equal(output, test.expect);
     });
+
   });
 });


### PR DESCRIPTION
This is WIP-branch to get the project covered by browser tests, not only V8 via node/iojs. It runs tests with [zuul](https://github.com/defunctzombie/zuul) which provides simple local browser testing, aswell as cloud testing on multiple browsers with [saucelabs](http://saucelabs.com).

**Running tests locally**
```bash
$ npm run test-browser-local
```

**Running in the cloud**
It requires a saucelabs account and [~/.zuulrc config](https://github.com/defunctzombie/zuul/wiki/Cloud-testing#2-educate-zuul):
```bash
$ npm run test-browser
```

**Issues**
Atm only `context-test.js` and `parse-test.js` are runned. The biggest test suite `render-test.js` still needs some creating thinking, as it reads test fixtures and expected output from files in `test/_files` which doesnt work too well in browsers.

Greatly appreciate any thoughts about this, especially how we'll get `render-test.js` running in browsers.