### PR TITLE
Minor changes to make it compatible with both WSH and ASP

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -11,7 +11,7 @@
   } else if (typeof define === 'function' && define.amd) {
     define(['exports'], factory); // AMD
   } else {
-    factory(global.Mustache = {}); // <script>
+    factory(Mustache = {}); // script, wsh, asp
   }
 }(this, function mustacheFactory (mustache) {
 


### PR DESCRIPTION
`<script>`, even in comments, triggers `Active Server Pages error 'ASP 0138', Nested Script Block` Error.

Also, using `global ← this` pattern works on WSH but not on ASP, it's better to just Mustache = {}, since its less typing, works on all platforms and it's the the desired behavior.