### PR TITLE
Improve CLI parsing error

### DIFF
--- a/bin/mustache
+++ b/bin/mustache
@@ -46,8 +46,21 @@ function readView(cb) {
   var view = isStdin(viewArg) ? process.openStdin() : fs.createReadStream(viewArg);
 
   streamToStr(view, function(str) {
-    cb(JSON.parse(str));
+    cb(parseView(str));
   });
+}
+
+function parseView(str) {
+  try {
+    return JSON.parse(str);
+  } catch (ex) {
+    console.error(
+      'Shooot, could not parse view as JSON.\n'+
+      'Tips: functions are not valid JSON and keys / values must be surround with double quotes.\n\n'+
+      ex.stack);
+
+    process.exit(1);
+  }
 }
 
 function readTemplate(cb) {

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -28,6 +28,13 @@ describe('Mustache CLI', function () {
     });
   });
 
+  it('writes hints about JSON parsing errors when given invalid JSON', function(done) {
+    exec('echo {name:"lebron"} | bin/mustache - test/_files/cli.mustache', function(err, stdout, stderr) {
+      assert.notEqual(stderr.indexOf('Shooot, could not parse view as JSON'), -1);
+      done();
+    });
+  });
+
   it('writes module version into stdout when runned with --version', function(done){
     exec('bin/mustache --version', function(err, stdout, stderr) {
       assert.notEqual(stdout.indexOf(moduleVersion), -1);


### PR DESCRIPTION
I've become fund of human readable and informative error messages with tips lately ;) Would you agree this has some benefits compared to the raw exception stack from `JSON.parse()`?

Somewhat inspired by issue #429 expecting functions to be valid JSON.

```bash
→ echo {name:'lebron'} | ./bin/mustache - test/_files/cli.mustache 
undefined:1
{name:lebron}
 ^
SyntaxError: Unexpected token n
    at Object.parse (native)
    at /mustache.js/bin/mustache:49:13
```
vs
```bash
→ echo {name:'lebron'} | ./bin/mustache - test/_files/cli.mustache 
Shooot, could not parse view as JSON.
Tips: functions are not valid JSON and keys / values must be surround with double quotes.

SyntaxError: Unexpected token n
    at Object.parse (native)
    at parseView (/mustache.js/bin/mustache:55:17)
    at /mustache.js/bin/mustache:49:8
```