### PR TITLE
Added the keywords "imports", "nested" and "subtemplates" to the docs…

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,8 @@ Mustache requires only this:
 {{> next_more}}
 ```
 
-Why? Because the `next_more.mustache` file will inherit the `size` and `start` variables from the calling context. In this way you may want to think of partials as includes, or template expansion, even though it's not literally true.
+Why? Because the `next_more.mustache` file will inherit the `size` and `start` variables from the calling context. In this way you may want to think of partials as includes, imports, template expansion, nested templates, or subtemplates, even though those aren't literally the case here.
+
 
 For example, this template and partial:
 


### PR DESCRIPTION
… for Partials.  It took me forever to find this feature because those were the keywords I was looking for.  The term "partials" means something slightly different in some circles, so I kept misinterpretting their use when skimming the docs.