### PR TITLE
Bugfix for view context cache

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -356,7 +356,7 @@
     var cache = this.cache;
 
     var value;
-    if (name in cache) {
+    if (cache.hasOwnProperty(name)) {
       value = cache[name];
     } else {
       var context = this, names, index, lookupHit = false;

--- a/test/_files/avoids_obj_prototype_in_view_cache.js
+++ b/test/_files/avoids_obj_prototype_in_view_cache.js
@@ -1,0 +1,4 @@
+({
+  valueOf: 'Avoids methods',
+  watch: 'in Object.prototype'
+})

--- a/test/_files/avoids_obj_prototype_in_view_cache.mustache
+++ b/test/_files/avoids_obj_prototype_in_view_cache.mustache
@@ -1,0 +1,1 @@
+{{valueOf}} {{watch}}

--- a/test/_files/avoids_obj_prototype_in_view_cache.txt
+++ b/test/_files/avoids_obj_prototype_in_view_cache.txt
@@ -1,0 +1,1 @@
+Avoids methods in Object.prototype


### PR DESCRIPTION
The context cache looked up previously cached values by matching `cache.property` rather than `cache.hasOwnProperty()`. This resulted in some values getting used from `Object.prototype` rather than ignoring that value.

Fixes #442