### PR TITLE
Throw error when providing .render() with invalid template type

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -25,6 +25,14 @@
     return typeof object === 'function';
   }
 
+  /**
+   * More correct typeof string handling array
+   * which normally returns typeof 'object'
+   */
+  function typeStr (obj) {
+    return isArray(obj) ? 'array' : typeof obj;
+  }
+
   function escapeRegExp (string) {
     return string.replace(/[\-\[\]{}()*+?.,\\\^$|#\s]/g, '\\$&');
   }
@@ -584,6 +592,12 @@
    * default writer.
    */
   mustache.render = function render (template, view, partials) {
+    if (typeof template !== 'string') {
+      throw new TypeError('Invalid template! Template should be a "string" ' +
+                          'but "' + typeStr(template) + '" was given as the first ' +
+                          'argument for mustache#render(template, view, partials)');
+    }
+
     return defaultWriter.render(template, view, partials);
   };
 

--- a/test/render-test-browser-tmpl.mustache
+++ b/test/render-test-browser-tmpl.mustache
@@ -5,6 +5,12 @@ describe('Mustache.render', function () {
     Mustache.clearCache();
   });
 
+  it('requires template to be a string', function () {
+    assert.throws(function () {
+      Mustache.render(['dummy template'], ['foo', 'bar']);
+    }, TypeError, 'Invalid template! Template should be a "string" but "array" was given');
+  });
+
   var i;
   var tests = {{{.}}};
 

--- a/test/render-test.js
+++ b/test/render-test.js
@@ -9,6 +9,14 @@ describe('Mustache.render', function () {
     Mustache.clearCache();
   });
 
+  it('requires template to be a string', function () {
+    assert.throws(function () {
+      Mustache.render(['dummy template'], ['foo', 'bar']);
+    }, TypeError, 'Invalid template! Template should be a "string" but ' +
+                  '"array" was given as the first argument ' +
+                  'for mustache#render(template, view, partials)');
+  });
+
   tests.forEach(function (test) {
     var view = eval(test.view);
 


### PR DESCRIPTION
As we require the template to be a `string` we now throw an error when given any other data type. This should provide the developers with a meaningful error rather than a cryptic TypeError from the murky depths of our source code.

Fixes #464