### PR TITLE
Documents use of string literals containing double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The most basic tag type is a simple variable. A `{{name}}` tag renders the value
 
 All variables are HTML-escaped by default. If you want to render unescaped HTML, use the triple mustache: `{{{name}}}`. You can also use `&` to unescape a variable.
 
+To print `{{name}}` as a string literal, the default delimiters must be changed. See the ["Set Delimiter'](https://github.com/janl/mustache.js#set-delimiter) section for more information about custom delimiters.
+
 View:
 
 ```json
@@ -123,6 +125,9 @@ Template:
 * {{company}}
 * {{{company}}}
 * {{&company}}
+{{=<% %>=}}
+* {{company}}
+<%={{ }}=%>
 ```
 
 Output:
@@ -133,6 +138,7 @@ Output:
 * &lt;b&gt;GitHub&lt;/b&gt;
 * <b>GitHub</b>
 * <b>GitHub</b>
+* {{company}}
 ```
 
 JavaScript's dot notation may be used to access keys that are properties of objects in a view.


### PR DESCRIPTION
Currently, the documentation is not clear about how to write a double-quoted word as a string literal. This PR corrects that. For example, if you want `{{name}}` to be interpreted as a string literal rather than a mustache tag, you must change and then restore the default delimiter. 

View:

```json
{
  "name": "literal"
}
```

Template:

```html
* {{name}}
{{=<% %>=}}
* {{name}}
<%={{ }}=%>
```

Output:

```html
* literal
* {{name}}
```