### PR TITLE
Update UMD Shim to be resilient to HTMLElement global pollution

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -6,7 +6,7 @@
 /*global define: false Mustache: true*/
 
 (function defineMustache (global, factory) {
-  if (typeof exports === 'object' && exports) {
+  if (typeof exports === 'object' && exports && typeof exports.nodeName !== 'string') {
     factory(exports); // CommonJS
   } else if (typeof define === 'function' && define.amd) {
     define(['exports'], factory); // AMD


### PR DESCRIPTION
Please see https://github.com/umdjs/umd/pull/63 and https://github.com/umdjs/umd/issues/35 for more information, but this change prevents an HTML element with an id of `exports` from causing the UMD shim to incorrectly detect the environment as node.