### PR TITLE
Remove IE8 from zuul test runs

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -5,4 +5,4 @@ browsers:
   - name: firefox
     version: latest
   - name: ie
-    version: 8..latest
+    version: 9..latest


### PR DESCRIPTION
Running tests in IE8 stopped working backing in may when chai got introduced for assertions. It doesnt fail, but it shows as a red warning in the zuul output.

`- failed: <internet explorer 8 on Windows 2003> (0 failed, 0 passed)`

As IE8 gets less and less usage and support around the interwebs, I vote for running tests in IE9 =&gt;

*Commit introducing chai with comments:*  https://github.com/janl/mustache.js/commit/954a8fbf15dc956b754355e9a0681202628724b3