### PR TITLE
Removed html syntax highlighting on README.md example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ View:
 
 Template:
 
-```html
+```
 * {{name}}
 * {{age}}
 * {{company}}


### PR DESCRIPTION
This is just a silly request/nitpick, but with the html syntax highlighting this example looks just like plain text, except for the ampersand, which appears highlighted in red. This could be cause confusion, signaling that there is something "more important" about the ampersand than the rest of keywords (e.g. the delimiters).