### PR TITLE
Add support for resolving template functions using object prototype 

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -414,8 +414,13 @@
       cache[name] = value;
     }
 
-    if (isFunction(value))
-      value = value.call(this.view);
+    if (isFunction(value)){
+      if (names && names.length > 1 && typeof Object.getPrototypeOf(names[names.length-2])[names[names.length-1]] === 'function'){
+        value = value.call(names[names.length-2]);
+      } else {
+        value = value.call(this.view);
+      }
+    }
 
     return value;
   };


### PR DESCRIPTION
Currently function calls are resolved against the current view object.

This will allow for scenarios like [issue 498](https://github.com/janl/mustache.js/issues/498) so that the template can be rendered using an object prototype function directly.
