### PR TITLE
Improve HTML escaping

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -63,11 +63,13 @@
     '>': '&gt;',
     '"': '&quot;',
     "'": '&#39;',
-    '/': '&#x2F;'
+    '/': '&#x2F;',
+    '`': '&#x60;',
+    '=': '&#x3D;'
   };
 
   function escapeHtml (string) {
-    return String(string).replace(/[&<>"'\/]/g, function fromEntityMap (s) {
+    return String(string).replace(/[&<>"'`=\/]/g, function fromEntityMap (s) {
       return entityMap[s];
     });
   }

--- a/test/_files/escaped.js
+++ b/test/_files/escaped.js
@@ -2,5 +2,5 @@
   title: function () {
     return "Bear > Shark";
   },
-  entities: "&quot; \"'<>/"
+  entities: "&quot; \"'<>`=/"
 })

--- a/test/_files/escaped.txt
+++ b/test/_files/escaped.txt
@@ -1,2 +1,2 @@
 <h1>Bear &gt; Shark</h1>
-And even &amp;quot; &quot;&#39;&lt;&gt;&#x2F;, but not &quot; "'<>/.
+And even &amp;quot; &quot;&#39;&lt;&gt;&#x60;&#x3D;&#x2F;, but not &quot; "'<>`=/.


### PR DESCRIPTION
This closes a couple of potential exploit scenarios:
* Backtick (`) for older IEs 
* Equals (=) for unquoted attributes

Also did some digging into what backslash (\\) could cause of trouble, no issues found, couldn't find any other encoding libraries doing anything with backslash either.

Refs https://github.com/wycats/handlebars.js/commit/83b8e846a3569bd366cf0b6bdc1e4604d1a2077e
Closes https://github.com/janl/mustache.js/pull/388