### PR TITLE
Fix inconsistency in defining global mustache object.

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -12,7 +12,7 @@
     define(['exports'], factory); // AMD
   } else {
     global.Mustache = {};
-    factory(Mustache); // script, wsh, asp
+    factory(global.Mustache); // script, wsh, asp
   }
 }(this, function mustacheFactory (mustache) {
 


### PR DESCRIPTION
A small fix as `global.Mustache` and `Mustache` may refer to two different things at this point. It worked before ok when Mustache was included in the default global `window` context - but for example if the script would have been included by wrapping Mustache code inside a function - this did cause issues.