### PR TITLE
Add optional `output` argument to mustache bin

### DIFF
--- a/bin/mustache
+++ b/bin/mustache
@@ -16,13 +16,14 @@ while ((partialArgIndex = process.argv.indexOf('-p')) > -1) {
 
 var viewArg = process.argv[2];
 var templateArg = process.argv[3];
+var outputArg = process.argv[4];
 
 if (hasVersionArg()) {
   return console.log(pkg.version);
 }
 
 if (!templateArg || !viewArg) {
-  console.error('Syntax: mustache <view> <template>');
+  console.error('Syntax: mustache <view> <template> [output]');
   process.exit(1);
 }
 
@@ -92,7 +93,11 @@ function render (cb, templateStr, jsonView) {
 }
 
 function toStdout (cb, str) {
-  cb(process.stdout.write(str));
+  if (outputArg) {
+    cb(fs.writeFileSync(outputArg, str));
+  } else {
+    cb(process.stdout.write(str));
+  }
 }
 
 function streamToStr (stream, cb) {

--- a/test/_files/cli_output.txt
+++ b/test/_files/cli_output.txt
@@ -1,0 +1,1 @@
+Howdy LeBron, CLI rox

--- a/test/_files/cli_output.txt
+++ b/test/_files/cli_output.txt
@@ -1,1 +1,0 @@
-Howdy LeBron, CLI rox

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -60,6 +60,17 @@ describe('Mustache CLI', function () {
       });
     });
 
+    it('writes rendered template into the file specified by the third argument', function(done) {
+      var outputFile = 'test/_files/cli_output.txt';
+      exec('bin/mustache test/_files/cli.json test/_files/cli.mustache ' + outputFile, function(err, stdout, stderr) {
+        assert.equal(err, null);
+        assert.equal(stderr, '');
+        assert.equal(stdout, '');
+        assert.equal(fs.readFileSync(outputFile), expectedOutput);
+        done();
+      });
+    });
+
     it('reads view data from stdin when first argument equals "-"', function(done){
       exec('cat test/_files/cli.json | bin/mustache - test/_files/cli.mustache', function(err, stdout, stderr) {
         assert.equal(err, null);

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -67,6 +67,7 @@ describe('Mustache CLI', function () {
         assert.equal(stderr, '');
         assert.equal(stdout, '');
         assert.equal(fs.readFileSync(outputFile), expectedOutput);
+        fs.unlink('test/_files/cli_output.txt');
         done();
       });
     });


### PR DESCRIPTION
I am not sure whether this PR is welcome, since I didn't see much people had a requirement for using this argument.
Yet we have been using this feature in production (because `> output` is forbidden in certain cases).
Feel free to close it if you find it confusing.
Thanks.