### PR TITLE
Fixes CLI tests for windows

### DIFF
--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -2,20 +2,19 @@ require('./helper');
 
 var fs = require('fs');
 var path = require('path');
+var child_process = require('child_process');
 var _files = path.join(__dirname, '_files');
 var cliTxt = path.resolve(_files, 'cli.txt');
 var cliPartialsTxt = path.resolve(_files, 'cli_with_partials.txt');
 var moduleVersion = require('../package').version;
 
-var child_process = require('child_process');
-
 function changeForOS(command) {
 
   if(process.platform === 'win32') {
-    return command.
-      replace(/bin\/mustache/g, 'node bin\\mustache').
-      replace(/\bcat\b/g, 'type').
-      replace(/\//g, '\\');
+    return command
+      .replace(/bin\/mustache/g, 'node bin\\mustache')
+      .replace(/\bcat\b/g, 'type')
+      .replace(/\//g, '\\');
   }
 
   return command;
@@ -31,7 +30,6 @@ describe('Mustache CLI', function () {
   var expectedOutput;
 
   it('writes syntax hints into stderr when runned with wrong number of arguments', function(done) {
-
     exec('bin/mustache', function(err, stdout, stderr) {
       assert.notEqual(stderr.indexOf('Syntax'), -1);
       done();
@@ -101,17 +99,14 @@ describe('Mustache CLI', function () {
 
     it('writes it couldnt find template into stderr when second argument doesnt resolve to a file', function(done) {
       exec('bin/mustache test/_files/cli.json test/_files/non-existing-template.mustache', function(err, stdout, stderr) {
-        console.log(stderr);
-        assert.notEqual(stderr.indexOf('Could not find file:'), -1);
-        assert.notEqual(stderr.indexOf(changeForOS('test/_files/non-existing-template.mustache')), -1);
+        assert.isOk(/Could not find file: .+non-existing-template\.mustache/.test(stderr));
         done();
       });
     });
 
     it('writes it couldnt find view into stderr when first argument doesnt resolve to a file', function(done) {
       exec('bin/mustache test/_files/non-existing-view.json test/_files/cli.mustache', function(err, stdout, stderr) {
-        assert.notEqual(stderr.indexOf('Could not find file:'), -1);
-        assert.notEqual(stderr.indexOf(changeForOS('test/_files/non-existing-view.json')), -1);
+        assert.isOk(/Could not find file: .+non-existing-view\.json/.test(stderr));
         done();
       });
     });

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -7,18 +7,23 @@ var cliTxt = path.resolve(_files, 'cli.txt');
 var cliPartialsTxt = path.resolve(_files, 'cli_with_partials.txt');
 var moduleVersion = require('../package').version;
 
-var exec = require('child_process').exec;
+var child_process = require('child_process');
 
 function changeForOS(command) {
 
   if(process.platform === 'win32') {
     return command.
       replace(/bin\/mustache/g, 'node bin\\mustache').
-      replace(/cat /g, 'type ').
+      replace(/\bcat\b/g, 'type').
       replace(/\//g, '\\');
   }
 
   return command;
+}
+
+function exec() {
+  arguments[0] = changeForOS(arguments[0]);
+  return child_process.exec.apply(child_process, arguments);
 }
 
 describe('Mustache CLI', function () {
@@ -27,28 +32,28 @@ describe('Mustache CLI', function () {
 
   it('writes syntax hints into stderr when runned with wrong number of arguments', function(done) {
 
-    exec(changeForOS('bin/mustache'), function(err, stdout, stderr) {
+    exec('bin/mustache', function(err, stdout, stderr) {
       assert.notEqual(stderr.indexOf('Syntax'), -1);
       done();
     });
   });
 
   it('writes hints about JSON parsing errors when given invalid JSON', function(done) {
-    exec(changeForOS('echo {name:"lebron"} | bin/mustache - test/_files/cli.mustache'), function(err, stdout, stderr) {
+    exec('echo {name:"lebron"} | bin/mustache - test/_files/cli.mustache', function(err, stdout, stderr) {
       assert.notEqual(stderr.indexOf('Shooot, could not parse view as JSON'), -1);
       done();
     });
   });
 
   it('writes module version into stdout when runned with --version', function(done){
-    exec(changeForOS('bin/mustache --version'), function(err, stdout, stderr) {
+    exec('bin/mustache --version', function(err, stdout, stderr) {
       assert.notEqual(stdout.indexOf(moduleVersion), -1);
       done();
     });
   });
 
   it('writes module version into stdout when runned with -v', function(done){
-    exec(changeForOS('bin/mustache -v'), function(err, stdout, stderr) {
+    exec('bin/mustache -v', function(err, stdout, stderr) {
       assert.notEqual(stdout.indexOf(moduleVersion), -1);
       done();
     });
@@ -65,7 +70,7 @@ describe('Mustache CLI', function () {
     });
 
     it('writes rendered template into stdout when successfull', function(done) {
-      exec(changeForOS('bin/mustache test/_files/cli.json test/_files/cli.mustache'), function(err, stdout, stderr) {
+      exec('bin/mustache test/_files/cli.json test/_files/cli.mustache', function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, expectedOutput);
@@ -75,7 +80,7 @@ describe('Mustache CLI', function () {
 
     it('writes rendered template into the file specified by the third argument', function(done) {
       var outputFile = 'test/_files/cli_output.txt';
-      exec(changeForOS('bin/mustache test/_files/cli.json test/_files/cli.mustache ' + outputFile), function(err, stdout, stderr) {
+      exec('bin/mustache test/_files/cli.json test/_files/cli.mustache ' + outputFile, function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, '');
@@ -86,7 +91,7 @@ describe('Mustache CLI', function () {
     });
 
     it('reads view data from stdin when first argument equals "-"', function(done){
-      exec(changeForOS('cat test/_files/cli.json | bin/mustache - test/_files/cli.mustache'), function(err, stdout, stderr) {
+      exec('cat test/_files/cli.json | bin/mustache - test/_files/cli.mustache', function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, expectedOutput);
@@ -95,7 +100,7 @@ describe('Mustache CLI', function () {
     });
 
     it('writes it couldnt find template into stderr when second argument doesnt resolve to a file', function(done) {
-      exec(changeForOS('bin/mustache test/_files/cli.json test/_files/non-existing-template.mustache'), function(err, stdout, stderr) {
+      exec('bin/mustache test/_files/cli.json test/_files/non-existing-template.mustache', function(err, stdout, stderr) {
         console.log(stderr);
         assert.notEqual(stderr.indexOf('Could not find file:'), -1);
         assert.notEqual(stderr.indexOf(changeForOS('test/_files/non-existing-template.mustache')), -1);
@@ -104,7 +109,7 @@ describe('Mustache CLI', function () {
     });
 
     it('writes it couldnt find view into stderr when first argument doesnt resolve to a file', function(done) {
-      exec(changeForOS('bin/mustache test/_files/non-existing-view.json test/_files/cli.mustache'), function(err, stdout, stderr) {
+      exec('bin/mustache test/_files/non-existing-view.json test/_files/cli.mustache', function(err, stdout, stderr) {
         assert.notEqual(stderr.indexOf('Could not find file:'), -1);
         assert.notEqual(stderr.indexOf(changeForOS('test/_files/non-existing-view.json')), -1);
         done();
@@ -124,7 +129,7 @@ describe('Mustache CLI', function () {
     });
 
     it('writes rendered template with partials into stdout', function(done) {
-      exec(changeForOS('bin/mustache test/_files/cli_with_partials.json test/_files/cli_with_partials.mustache -p test/_files/cli.mustache -p test/_files/comments.mustache'), function(err, stdout, stderr) {
+      exec('bin/mustache test/_files/cli_with_partials.json test/_files/cli_with_partials.mustache -p test/_files/cli.mustache -p test/_files/comments.mustache', function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, expectedOutput);
@@ -133,7 +138,7 @@ describe('Mustache CLI', function () {
     });
 
     it('writes rendered template with partials when partials args before required args', function(done) {
-      exec(changeForOS('bin/mustache -p test/_files/cli.mustache -p test/_files/comments.mustache test/_files/cli_with_partials.json test/_files/cli_with_partials.mustache'), function(err, stdout, stderr) {
+      exec('bin/mustache -p test/_files/cli.mustache -p test/_files/comments.mustache test/_files/cli_with_partials.json test/_files/cli_with_partials.mustache', function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, expectedOutput);

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -9,33 +9,46 @@ var moduleVersion = require('../package').version;
 
 var exec = require('child_process').exec;
 
+function changeForOS(command) {
+
+  if(process.platform === 'win32') {
+    return command.
+      replace(/bin\/mustache/g, 'node bin\\mustache').
+      replace(/cat /g, 'type ').
+      replace(/\//g, '\\');
+  }
+
+  return command;
+}
+
 describe('Mustache CLI', function () {
 
   var expectedOutput;
 
   it('writes syntax hints into stderr when runned with wrong number of arguments', function(done) {
-    exec('bin/mustache', function(err, stdout, stderr) {
+
+    exec(changeForOS('bin/mustache'), function(err, stdout, stderr) {
       assert.notEqual(stderr.indexOf('Syntax'), -1);
       done();
     });
   });
 
   it('writes hints about JSON parsing errors when given invalid JSON', function(done) {
-    exec('echo {name:"lebron"} | bin/mustache - test/_files/cli.mustache', function(err, stdout, stderr) {
+    exec(changeForOS('echo {name:"lebron"} | bin/mustache - test/_files/cli.mustache'), function(err, stdout, stderr) {
       assert.notEqual(stderr.indexOf('Shooot, could not parse view as JSON'), -1);
       done();
     });
   });
 
   it('writes module version into stdout when runned with --version', function(done){
-    exec('bin/mustache --version', function(err, stdout, stderr) {
+    exec(changeForOS('bin/mustache --version'), function(err, stdout, stderr) {
       assert.notEqual(stdout.indexOf(moduleVersion), -1);
       done();
     });
   });
 
   it('writes module version into stdout when runned with -v', function(done){
-    exec('bin/mustache -v', function(err, stdout, stderr) {
+    exec(changeForOS('bin/mustache -v'), function(err, stdout, stderr) {
       assert.notEqual(stdout.indexOf(moduleVersion), -1);
       done();
     });
@@ -52,7 +65,7 @@ describe('Mustache CLI', function () {
     });
 
     it('writes rendered template into stdout when successfull', function(done) {
-      exec('bin/mustache test/_files/cli.json test/_files/cli.mustache', function(err, stdout, stderr) {
+      exec(changeForOS('bin/mustache test/_files/cli.json test/_files/cli.mustache'), function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, expectedOutput);
@@ -62,7 +75,7 @@ describe('Mustache CLI', function () {
 
     it('writes rendered template into the file specified by the third argument', function(done) {
       var outputFile = 'test/_files/cli_output.txt';
-      exec('bin/mustache test/_files/cli.json test/_files/cli.mustache ' + outputFile, function(err, stdout, stderr) {
+      exec(changeForOS('bin/mustache test/_files/cli.json test/_files/cli.mustache ' + outputFile), function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, '');
@@ -73,7 +86,7 @@ describe('Mustache CLI', function () {
     });
 
     it('reads view data from stdin when first argument equals "-"', function(done){
-      exec('cat test/_files/cli.json | bin/mustache - test/_files/cli.mustache', function(err, stdout, stderr) {
+      exec(changeForOS('cat test/_files/cli.json | bin/mustache - test/_files/cli.mustache'), function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, expectedOutput);
@@ -82,15 +95,18 @@ describe('Mustache CLI', function () {
     });
 
     it('writes it couldnt find template into stderr when second argument doesnt resolve to a file', function(done) {
-      exec('bin/mustache test/_files/cli.json test/_files/non-existing-template.mustache', function(err, stdout, stderr) {
-        assert.notEqual(stderr.indexOf('Could not find file: test/_files/non-existing-template.mustache'), -1);
+      exec(changeForOS('bin/mustache test/_files/cli.json test/_files/non-existing-template.mustache'), function(err, stdout, stderr) {
+        console.log(stderr);
+        assert.notEqual(stderr.indexOf('Could not find file:'), -1);
+        assert.notEqual(stderr.indexOf(changeForOS('test/_files/non-existing-template.mustache')), -1);
         done();
       });
     });
 
     it('writes it couldnt find view into stderr when first argument doesnt resolve to a file', function(done) {
-      exec('bin/mustache test/_files/non-existing-view.json test/_files/cli.mustache', function(err, stdout, stderr) {
-        assert.notEqual(stderr.indexOf('Could not find file: test/_files/non-existing-view.json'), -1);
+      exec(changeForOS('bin/mustache test/_files/non-existing-view.json test/_files/cli.mustache'), function(err, stdout, stderr) {
+        assert.notEqual(stderr.indexOf('Could not find file:'), -1);
+        assert.notEqual(stderr.indexOf(changeForOS('test/_files/non-existing-view.json')), -1);
         done();
       });
     });
@@ -108,7 +124,7 @@ describe('Mustache CLI', function () {
     });
 
     it('writes rendered template with partials into stdout', function(done) {
-      exec('bin/mustache test/_files/cli_with_partials.json test/_files/cli_with_partials.mustache -p test/_files/cli.mustache -p test/_files/comments.mustache', function(err, stdout, stderr) {
+      exec(changeForOS('bin/mustache test/_files/cli_with_partials.json test/_files/cli_with_partials.mustache -p test/_files/cli.mustache -p test/_files/comments.mustache'), function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, expectedOutput);
@@ -117,7 +133,7 @@ describe('Mustache CLI', function () {
     });
 
     it('writes rendered template with partials when partials args before required args', function(done) {
-      exec('bin/mustache -p test/_files/cli.mustache -p test/_files/comments.mustache test/_files/cli_with_partials.json test/_files/cli_with_partials.mustache', function(err, stdout, stderr) {
+      exec(changeForOS('bin/mustache -p test/_files/cli.mustache -p test/_files/comments.mustache test/_files/cli_with_partials.json test/_files/cli_with_partials.mustache'), function(err, stdout, stderr) {
         assert.equal(err, null);
         assert.equal(stderr, '');
         assert.equal(stdout, expectedOutput);


### PR DESCRIPTION
Fixes https://github.com/janl/mustache.js/issues/559

All that was needed was a helper function for transforming *nix commands into windows commands:

* Makes sure `bin/mustache` is run with `node`
* Replaces `cat` with `type`
* Replaces forward slashes with backward slashes

Leaves commands as they are for *nix, so won't break the tests there

Also replaced the `Could not find file` strings to be compatible for windows