### PR TITLE
Ignore eslint for greenkeeper updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
       "wrappers"
     ]
   },
+  "greenkeper": {
+    "ignore": ["eslint"]
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
As we don't plan to update to Node.js v4 any time soon, we can't update eslint cause it requires Node.js => v4. Main benefit of adding this is to stop greenkeeper from opening new PRs for updating eslint.

Found hints about this hidden greenkeeper feature in https://github.com/greenkeeperio/greenkeeper/issues/47#issuecomment-146474309.

Refs #579