### PR TITLE
return mustache object from factory

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -626,4 +626,5 @@
   mustache.Context = Context;
   mustache.Writer = Writer;
 
+  return mustache;
 }));


### PR DESCRIPTION
When using amdclean to create a footprint less javascript file, the object needs to be returned to let it properly be assigned to the created script variable.
