### PR TITLE
Second shot at having greenkeeper ignore eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "wrappers"
     ]
   },
-  "greenkeper": {
+  "greenkeeper": {
     "ignore": ["eslint"]
   },
   "license": "MIT"


### PR DESCRIPTION
First shot at getting greenkeeper to ignoring eslint updates landed with commit 85fa74325845771fb3a5229ba319aa15bb57f3c3.

Sadly that commit had a minor `greenkeper` misspelling in package.json, which obviously didn't have much effect for greenkeeper. This commit fixes that blooper in hopes that greenkeeper will stop opening PRs about new eslint versions, as we don't want to update at the moment cause eslint 3.x requires Node.js v4.x.

Refs #600, #601, #603 and friends