### PR TITLE
global.Mustache triggers JScript runtime error

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -11,8 +11,8 @@
   } else if (typeof define === 'function' && define.amd) {
     define(['exports'], factory); // AMD
   } else {
-    global.Mustache = {};
-    factory(global.Mustache); // script, wsh, asp
+    Mustache = {};
+    factory(Mustache); // script, wsh, asp
   }
 }(this, function mustacheFactory (mustache) {
 


### PR DESCRIPTION
Because ASP/WSH script environments are language agnostic, one cannot assume it can be managed like a first-class javascript object. By changing the javascript global explicit assignment pattern to implicit assignment pattern (less is more) it works as expected.

Error before the change:
Microsoft JScript runtime error '800a01b6'
Object doesn't support this property or method
/lib/axe/classes/Parsers/mustache.asp, line 163