### PR TITLE
Resolve #589, and possibly fix other manifestations of this bug

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -42,7 +42,10 @@
    * including its prototype, has a given property
    */
   function hasProperty (obj, propName) {
-    return obj != null && (propName in obj);
+    return (
+      (obj != null && typeof obj === 'object' && (propName in obj))
+      || (obj !== undefined && obj.hasOwnProperty(propName))
+    );
   }
 
   // Workaround for https://issues.apache.org/jira/browse/COUCHDB-577

--- a/mustache.js
+++ b/mustache.js
@@ -428,16 +428,23 @@
           intermediateValue = context.view[name];
 
           /**
-           * Only checking against hasProperty, which always returns false if
-           * context.view is not an object. Deliberately omitting the check
-           * against primitiveHasOwnProperty if dot notation is not used.
+           * Only checking against `hasProperty`, which always returns `false` if
+           * `context.view` is not an object. Deliberately omitting the check
+           * against `primitiveHasOwnProperty` if dot notation is not used.
            *
            * Consider this example:
-           * Mustache.render("{{#length}}{{length}}{{/length}}", {length: "hello"})
+           * ```
+           * Mustache.render("The length of a football field is {{#length}}{{length}}{{/length}}.", {length: "100 yards"})
+           * ```
            *
-           * If we were to check also against primitiveHasOwnProperty, as we do
-           * in the dot notation case, then render call would return 5, rather
-           * than the expected "hello".
+           * If we were to check also against `primitiveHasOwnProperty`, as we do
+           * in the dot notation case, then render call would return:
+           *
+           * "The length of a football field is 9."
+           *
+           * rather than the expected:
+           *
+           * "The length of a football field is 100 yards."
            **/
           lookupHit = hasProperty(context.view, name);
         }

--- a/mustache.js
+++ b/mustache.js
@@ -42,9 +42,19 @@
    * including its prototype, has a given property
    */
   function hasProperty (obj, propName) {
+    return obj != null && typeof obj === 'object' && (propName in obj);
+  }
+
+  /**
+   * Safe way of detecting whether or not the given thing is a primitive and
+   * whether it has the given property
+   */
+  function primitiveHasOwnProperty (primitive, propName) {  
     return (
-      (obj != null && typeof obj === 'object' && (propName in obj))
-      || (obj !== undefined && obj.hasOwnProperty(propName))
+      typeof primitive !== 'object' 
+      && primitive !== undefined
+      && primitive.hasOwnProperty
+      && primitive.hasOwnProperty(propName)
     );
   }
 
@@ -401,7 +411,10 @@
            **/
           while (intermediateValue != null && index < names.length) {
             if (index === names.length - 1)
-              lookupHit = hasProperty(intermediateValue, names[index]);
+              lookupHit = (
+                hasProperty(intermediateValue, names[index]) 
+                || primitiveHasOwnProperty(intermediateValue, names[index])
+              );
 
             intermediateValue = intermediateValue[names[index++]];
           }

--- a/mustache.js
+++ b/mustache.js
@@ -377,11 +377,11 @@
     if (cache.hasOwnProperty(name)) {
       value = cache[name];
     } else {
-      var context = this, names, index, lookupHit = false;
+      var context = this, intermediateValue, names, index, lookupHit = false;
 
       while (context) {
         if (name.indexOf('.') > 0) {
-          value = context.view;
+          intermediateValue = context.view;
           names = name.split('.');
           index = 0;
 
@@ -396,19 +396,21 @@
            * This is specially necessary for when the value has been set to
            * `undefined` and we want to avoid looking up parent contexts.
            **/
-          while (value != null && index < names.length) {
+          while (intermediateValue != null && index < names.length) {
             if (index === names.length - 1)
-              lookupHit = hasProperty(value, names[index]);
+              lookupHit = hasProperty(intermediateValue, names[index]);
 
-            value = value[names[index++]];
+            intermediateValue = intermediateValue[names[index++]];
           }
         } else {
-          value = context.view[name];
+          intermediateValue = context.view[name];
           lookupHit = hasProperty(context.view, name);
         }
 
-        if (lookupHit)
+        if (lookupHit) {
+          value = intermediateValue;
           break;
+        }
 
         context = context.parent;
       }

--- a/mustache.js
+++ b/mustache.js
@@ -42,7 +42,7 @@
    * including its prototype, has a given property
    */
   function hasProperty (obj, propName) {
-    return obj != null && typeof obj === 'object' && (propName in obj);
+    return obj != null && (propName in obj);
   }
 
   // Workaround for https://issues.apache.org/jira/browse/COUCHDB-577

--- a/test/_files/dot_notation.js
+++ b/test/_files/dot_notation.js
@@ -19,5 +19,6 @@
   truthy: {
     zero: 0,
     notTrue: false
-  }
+  },
+  singletonList: [{singletonItem: "singleton item"}]
 })

--- a/test/_files/dot_notation.mustache
+++ b/test/_files/dot_notation.mustache
@@ -8,4 +8,5 @@
 <p>Zero: {{truthy.zero}}</p>
 <p>False: {{truthy.notTrue}}</p>
 <p>length of string should be rendered: {{price.currency.name.length}}</p>
+<p>length of string in a list should be rendered: {{#singletonList}}{{singletonItem.length}}{{/singletonList}}</p>
 <p>length of an array should be rendered: {{authors.length}}</p>

--- a/test/_files/dot_notation.mustache
+++ b/test/_files/dot_notation.mustache
@@ -7,5 +7,5 @@
 <h2>Test truthy false values:</h2>
 <p>Zero: {{truthy.zero}}</p>
 <p>False: {{truthy.notTrue}}</p>
-<p>length of string should not be rendered: {{price.currency.name.length}}</p>
+<p>length of string should be rendered: {{price.currency.name.length}}</p>
 <p>length of an array should be rendered: {{authors.length}}</p>

--- a/test/_files/dot_notation.mustache
+++ b/test/_files/dot_notation.mustache
@@ -7,3 +7,4 @@
 <h2>Test truthy false values:</h2>
 <p>Zero: {{truthy.zero}}</p>
 <p>False: {{truthy.notTrue}}</p>
+<p>length of string should not be rendered: {{price.currency.name.length}}</p>

--- a/test/_files/dot_notation.mustache
+++ b/test/_files/dot_notation.mustache
@@ -8,3 +8,4 @@
 <p>Zero: {{truthy.zero}}</p>
 <p>False: {{truthy.notTrue}}</p>
 <p>length of string should not be rendered: {{price.currency.name.length}}</p>
+<p>length of an array should be rendered: {{authors.length}}</p>

--- a/test/_files/dot_notation.txt
+++ b/test/_files/dot_notation.txt
@@ -8,3 +8,4 @@
 <p>Zero: 0</p>
 <p>False: false</p>
 <p>length of string should not be rendered: </p>
+<p>length of an array should be rendered: 2</p>

--- a/test/_files/dot_notation.txt
+++ b/test/_files/dot_notation.txt
@@ -8,4 +8,5 @@
 <p>Zero: 0</p>
 <p>False: false</p>
 <p>length of string should be rendered: 3</p>
+<p>length of string in a list should be rendered: 14</p>
 <p>length of an array should be rendered: 2</p>

--- a/test/_files/dot_notation.txt
+++ b/test/_files/dot_notation.txt
@@ -7,5 +7,5 @@
 <h2>Test truthy false values:</h2>
 <p>Zero: 0</p>
 <p>False: false</p>
-<p>length of string should not be rendered: </p>
+<p>length of string should be rendered: 3</p>
 <p>length of an array should be rendered: 2</p>

--- a/test/_files/dot_notation.txt
+++ b/test/_files/dot_notation.txt
@@ -7,3 +7,4 @@
 <h2>Test truthy false values:</h2>
 <p>Zero: 0</p>
 <p>False: false</p>
+<p>length of string should not be rendered: </p>


### PR DESCRIPTION
Resolve #589 
Because `value` is used as an intermediate variable as well as the final return value of `lookup`, there is a possibility that `value` is returned even if the `hasProperty` test fails. In the reported issue, the string's `length` is stored in `value`, even though `lookupHit` is `false` (because a string has a `length` property but is not an `Object`). The outer loop breaks, and `value` is returned, incorrectly as the string's `length`. `lookup` should never return a value where the lookup is not hit, so don't use `value` as an intermediate variable -- only assign to it when we know that the `hasProperty` test passes.