### PR TITLE
Pass context.view to partials function

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -545,7 +545,9 @@
   Writer.prototype.renderPartial = function renderPartial (token, context, partials) {
     if (!partials) return;
 
-    var value = isFunction(partials) ? partials(token[1]) : partials[token[1]];
+    var value = isFunction(partials)
+      ? partials(token[1], context.view)
+      : partials[token[1]];
     if (value != null)
       return this.renderTokens(this.parse(value), context, partials, value);
   };


### PR DESCRIPTION
This idea arose from a project that I'm working on where I need to handle the logic for loading my own partials. This is because there might be hundreds of partials and I don't want to load all of them into memory (AKA using a partials object).

From parsing through the source code, I saw that the `partials` parameter for `renderPartial` can be a function. Great! However, when rendering through a function, I also need access to the context for the partial and currently, only the name of the partial is provided. This is where this PR comes is 😄.