### PR TITLE
Writer.prototype.parse to cache by tags in addition to template string

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -447,7 +447,7 @@
     var tokens = cache[template];
 
     if (tokens == null)
-      tokens = cache[template] = parseTemplate(template, tags);
+      tokens = cache[template + ':' + (tags || mustache.tags).join(':')] = parseTemplate(template, tags);
 
     return tokens;
   };

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -103,4 +103,36 @@ describe('Mustache.parse', function () {
     });
   });
 
+  describe('when parsing a template without tags specified followed by the same template with tags specified', function() {
+    it('returns different tokens for the latter parse', function() {
+      var template = "{{foo}}[bar]";
+      var parsedWithBraces = Mustache.parse(template);
+      var parsedWithBrackets = Mustache.parse(template, ['[', ']']);
+      assert.notDeepEqual(parsedWithBrackets, parsedWithBraces);
+    });
+  });
+
+  describe('when parsing a template with tags specified followed by the same template with different tags specified', function() {
+    it('returns different tokens for the latter parse', function() {
+      var template = "(foo)[bar]";
+      var parsedWithParens = Mustache.parse(template, ['(', ')']);
+      var parsedWithBrackets = Mustache.parse(template, ['[', ']']);
+      assert.notDeepEqual(parsedWithBrackets, parsedWithParens);
+    });
+  });
+
+  describe('when parsing a template after already having parsed that template with a different Mustache.tags', function() {
+    it('returns different tokens for the latter parse', function() {
+      var template = "{{foo}}[bar]";
+      var parsedWithBraces = Mustache.parse(template, ['(', ')']);
+
+      var oldTags = Mustache.tags;
+      Mustache.tags = ['[', ']'];
+      var parsedWithBrackets = Mustache.parse(template);
+      Mustache.tags = oldTags;
+
+      assert.notDeepEqual(parsedWithBrackets, parsedWithBraces);
+    });
+  });
+
 });

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -124,7 +124,7 @@ describe('Mustache.parse', function () {
   describe('when parsing a template after already having parsed that template with a different Mustache.tags', function() {
     it('returns different tokens for the latter parse', function() {
       var template = "{{foo}}[bar]";
-      var parsedWithBraces = Mustache.parse(template, ['(', ')']);
+      var parsedWithBraces = Mustache.parse(template);
 
       var oldTags = Mustache.tags;
       Mustache.tags = ['[', ']'];


### PR DESCRIPTION
Resolve #617 
Because the results of `Writer.prototype.parse` depends on both the template string and the tags, it should cache by both 