### PR TITLE
Document global Mustache.escape overriding capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ function loadUser() {
 
 The most basic tag type is a simple variable. A `{{name}}` tag renders the value of the `name` key in the current context. If there is no such key, nothing is rendered.
 
-All variables are HTML-escaped by default. If you want to render unescaped HTML, use the triple mustache: `{{{name}}}`. You can also use `&` to unescape a variable.
+All variables are HTML-escaped by default. If you want to render unescaped HTML, use the triple mustache: `{{{name}}}`. You can also use `&` to unescape a variable. 
+
+If you'd like to change HTML-escaping behavior globally (for example, to template non-HTML formats), you can override Mustache's escape function. For example, to disable all escaping: `Mustache.escape = function(text) {return text;};`.
 
 If you want `{{name}}` _not_ to be interpreted as a mustache tag, but rather to appear exactly as `{{name}}` in the output, you must change and then restore the default delimiter. See the [Custom Delimiters](#custom-delimiters) section for more information.
 


### PR DESCRIPTION
Right now, the capacity to override HTML-escaping of strings globally isn't documented. Not only that, but the end of the main issue where this is discussed #244 proposes a solution that got implemented, but with a name that's slightly different from the actual user-facing name.  (The proposed solution is to overwrite `Mustache.escapeHTML`, but the actual name that client-facing code has to override is `Mustache.escape` --- which is only discovered if you dig down further and find #307. 

This capacity is super-useful, especially when combined with custom delimiters (where triple-mustache won't work). For example, I'm using Mustache to template LaTeX right now, and the capacity to override escaping globally is essential to keep me from going nuts. 

This PR just adds a line documenting this behavior. 