### PR TITLE
Readme: Mustache.parse returns an array of Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,12 @@ Mustache.render(
 Mustache.parse(
   template              : String,
   tags = ['{{', '}}']   : Tags,
-) => String
+) => Token[]
+
+interface Token [String, String, Number, Number, Token[]?, Number?]
 
 interface Tags [String, String]
+
 ```
 
 ## Templates


### PR DESCRIPTION
In the README the return type for Mustache.parse is listed as a String. It's actually an array of Tokens.