### PR TITLE
Install release tools with npm rather than via pre-commit hook

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,31 +7,19 @@ def minified_file
   ENV['FILE'] || 'mustache.min.js'
 end
 
-task :install_mocha do
-  sh "npm install -g mocha" if `which mocha`.empty?
-end
-
-task :install_uglify do
-  sh "npm install -g uglify-js" if `which uglifyjs`.empty?
-end
-
-task :install_jshint do
-  sh "npm install -g jshint" if `which jshint`.empty?
-end
-
 desc "Run all tests"
 task :test => :install_mocha do
-  sh "mocha test"
+  sh "./node_modules/.bin/mocha test"
 end
 
 desc "Make a compressed build in #{minified_file}"
 task :minify => :install_uglify do
-  sh "uglifyjs mustache.js > #{minified_file}"
+  sh "./node_modules/.bin/uglifyjs mustache.js > #{minified_file}"
 end
 
 desc "Run JSHint"
 task :hint => :install_jshint do
-  sh "jshint mustache.js"
+  sh "./node_modules/.bin/jshint mustache.js"
 end
 
 # Creates a task that uses the various template wrappers to make a wrapped

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -72,11 +72,6 @@ class Bumper
 	def did_bump
 		if !@bumped
 			puts 'bump detected!'
-			if `which uglifyjs`.empty?
-				puts_c 31, 'you need uglifyjs installed'
-				puts 'run `sudo npm install -g uglify-js`'
-				exit 1
-			end
 		end
 		@bumped = true
 	end

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   "devDependencies": {
     "chai": "^3.4.0",
     "eslint": "^2.5.1",
+    "jshint": "^2.9.5",
     "mocha": "^3.0.2",
+    "uglify-js": "^3.4.6",
     "zuul": "^3.11.0"
   },
   "spm": {


### PR DESCRIPTION
*In preparation for publish a couple of new versions of mustache.js, I stumbled upon a couple of improvements.*

Previously mocha, uglifyjs and jshint used when publishing a new version were ensured / installed by `Rakefile` via the pre-commit git hook. Those modules were automatically installed globally if not present in `$PATH`.

Installing modules globally has one particular downside that we should avoid: we can't ensure developers publishing new mustache.js versions have the same version of these 3rd party modules installed.

If instead we make these modules local dev dependencies, we can ensure which versions are installed, and we make 3rd party dependencies explicit by listing them in `package.json`, rather than in `Rakefile`.