### PR TITLE
Fix browser test suite by using Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - 4
   - 6
 before_install:
-  - npm install -g npm@2.x
+  - "test $TRAVIS_NODE_VERSION != '0.8' || npm install -g npm@2.x"
 script:
   - npm test
   - "test $TRAVIS_PULL_REQUEST != 'false' || test $TRAVIS_NODE_VERSION != '6' || npm run test-browser"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ node_js:
   - '0.10'
   - 0.12
   - 4
+  - 6
 before_install:
   - npm install -g npm@2.x
 script:
   - npm test
-  - "test $TRAVIS_PULL_REQUEST != 'false' || test $TRAVIS_NODE_VERSION != '4' || npm run test-browser"
+  - "test $TRAVIS_PULL_REQUEST != 'false' || test $TRAVIS_NODE_VERSION != '6' || npm run test-browser"
 env:
   global:
   - secure: L0dg0jr2fwkc2tPwP5svybILPBn2qdLzMrWc5tEXg3MPcy8D59Gvf+ri7INqo+ETPM20o5CsaDCH+LHUNS/V0G4VG1ajvsy7d8uh3hnb/K6VfVui/CjsHIqOcOZrbxVxgyX+iMXEXAj0+Syow9uDQHVhrz1qqad1n79likNCXa4=


### PR DESCRIPTION
For a long time we've struggled getting the browser test suite to run on [Sauce Labs](https://saucelabs.com/). Those tests were running on Node.js 4 which is getting quite old.

In a trial-n-error effort, I tried adding Node.js 6 as one of the versions to run on Travis CI, and at the same time ensure the browsers tests were run on that version instead of Node.js 4. Voila [the suite passed right away](https://travis-ci.org/janl/mustache.js/jobs/411477352), at least it did when in a feature branch, 🤞 it will still work when merged to master.

It therefore seemed like the issues we were seeing had to do with us running those tests via Node.js 4.

Also snook in a change for installing npm v2.x only when running tests on Node.js 0.8