### PR TITLE
Use ngrok rather than localtunnel when running browser tests

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -6,3 +6,7 @@ browsers:
     version: latest
   - name: ie
     version: 9..latest
+concurrency: 1
+tunnel:
+  type: ngrok
+  bind_tls: false

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "jshint": "^2.9.5",
     "mocha": "^3.0.2",
     "uglify-js": "^3.4.6",
-    "zuul": "^3.11.0"
+    "zuul": "^3.11.0",
+    "zuul-ngrok": "nolanlawson/zuul-ngrok#patch-1"
   },
   "spm": {
     "main": "mustache.js",


### PR DESCRIPTION
These changes makes zuul use ngrok for exposing itself to the outside world, rather than the default localtunnel implementation. That's because we've had quite a lot of issues with flakyness which seems to be related to localtunnel, e.g.:

```
- starting: <internet explorer 9 on Windows 2008>
events.js:160
      throw er; // Unhandled 'error' event
      ^
Error: connection refused: localtunnel.me:44896 (check your firewall settings)
    at Socket.<anonymous> (/home/travis/build/janl/mustache.js/node_modules/localtunnel/client.js:84:32)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at emitErrorNT (net.js:1290:8)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickCallback (internal/process/next_tick.js:104:9)
```

I thought this was fixed by [using Node.js 6 instead of Node.js 4](https://github.com/janl/mustache.js/pull/667), but sadly that was not the case as it re-appeared with Node.js 6 as well.

Had to use a [custom version of zuul-ngrok](https://github.com/rase-/zuul-ngrok/pull/12) which contains a newer version of ngrok. The dependency used by the upstream module threw an error when running on my computer, the updated version worked as a charm though. We should change to using the upstream module as soon as the PR with that ngrok version bump lands.

Set `concurrency: 1` otherwise ngrok would fail and make IE11 tests stall forever because of too many connections being made within a short time period. I've notice it can take quite some time (20+ minutes) to get all the tests through as it seems ngrok still seems to throttle the connections somehow, but the important thing is getting these tests to work.