### PR TITLE
issue #672: add `tags` parameter to `render`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ Following is an [rtype](https://git.io/rtype) signature of the most commonly use
 
 ```js
 Mustache.render(
-  template  : String,
-  view      : Object,
-  partials? : Object,
+  template            : String,
+  view                : Object,
+  partials?           : Object,
+  tags = ['{{', '}}'] : Tags,
 ) => String
 
 Mustache.parse(
@@ -504,15 +505,15 @@ Custom delimiters can be used in place of `{{` and `}}` by setting the new value
 
 #### Setting in JavaScript
 
-The `Mustache.tags` property holds an array consisting of the opening and closing tag values. Set custom values by passing a new array of tags to `parse()`, which gets honored over the default values, or by overriding the `tags` property itself:
+The `Mustache.tags` property holds an array consisting of the opening and closing tag values. Set custom values by passing a new array of tags to `render()`, which gets honored over the default values, or by overriding the `tags` property itself:
 
 ```js
 var customTags = [ '<%', '%>' ];
 ```
 
-##### Pass Value into Parse Method
+##### Pass Value into Render Method
 ```js
-Mustache.parse(template, customTags);
+Mustache.render(template, view, {}, customTags);
 ```
 
 ##### Override Tags Property

--- a/mustache.js
+++ b/mustache.js
@@ -461,9 +461,13 @@
    * names and templates of partials that are used in the template. It may
    * also be a function that is used to load partial templates on the fly
    * that takes a single argument: the name of the partial.
+   *
+   * If the optional `tags` argument is given here it must be an array with two
+   * string values: the opening and closing tags used in the template (e.g.
+   * [ "<%", "%>" ]). The default is to mustache.tags.
    */
-  Writer.prototype.render = function render (template, view, partials) {
-    var tokens = this.parse(template);
+  Writer.prototype.render = function render (template, view, partials, tags) {
+    var tokens = this.parse(template, tags);
     var context = (view instanceof Context) ? view : new Context(view);
     return this.renderTokens(tokens, context, partials, template);
   };
@@ -592,16 +596,18 @@
 
   /**
    * Renders the `template` with the given `view` and `partials` using the
-   * default writer.
+   * default writer. If the optional `tags` argument is given here it must be an
+   * array with two string values: the opening and closing tags used in the
+   * template (e.g. [ "<%", "%>" ]). The default is to mustache.tags.
    */
-  mustache.render = function render (template, view, partials) {
+  mustache.render = function render (template, view, partials, tags) {
     if (typeof template !== 'string') {
       throw new TypeError('Invalid template! Template should be a "string" ' +
                           'but "' + typeStr(template) + '" was given as the first ' +
                           'argument for mustache#render(template, view, partials)');
     }
 
-    return defaultWriter.render(template, view, partials);
+    return defaultWriter.render(template, view, partials, tags);
   };
 
   // This is here for backwards compatibility with 0.4.x.,

--- a/test/render-test.js
+++ b/test/render-test.js
@@ -17,6 +17,38 @@ describe('Mustache.render', function () {
                   'for mustache#render(template, view, partials)');
   });
 
+  it('uses tags argument instead of Mustache.tags when given', function () {
+    var template = '<<placeholder>>bar{{placeholder}}';
+
+    Mustache.tags = ['{{', '}}'];
+    assert.equal(Mustache.render(template, { placeholder: 'foo' }, {}, ['<<', '>>']), 'foobar{{placeholder}}');
+  });
+
+  it('uses tags argument instead of Mustache.tags when given, even when it previous rendered the template using Mustache.tags', function () {
+    var template = '((placeholder))bar{{placeholder}}';
+
+    Mustache.tags = ['{{', '}}'];
+    Mustache.render(template, { placeholder: 'foo' });
+    assert.equal(Mustache.render(template, { placeholder: 'foo' }, {}, ['((', '))']), 'foobar{{placeholder}}');
+  });
+
+  it('uses tags argument instead of Mustache.tags when given, even when it previous rendered the template using different tags', function () {
+    var template = '[[placeholder]]bar<<placeholder>>';
+
+    Mustache.render(template, { placeholder: 'foo' }, {}, ['<<', '>>']);
+    assert.equal(Mustache.render(template, { placeholder: 'foo' }, {}, ['[[', ']]']), 'foobar<<placeholder>>');
+  });
+
+  it('does not mutate Mustache.tags when given tags argument', function() {
+    var correctMustacheTags = ['{{', '}}'];
+    Mustache.tags = correctMustacheTags;
+
+    Mustache.render('((placeholder))', { placeholder: 'foo' }, {}, ['((', '))']);
+
+    assert.equal(Mustache.tags, correctMustacheTags);
+    assert.deepEqual(Mustache.tags, ['{{', '}}']);
+  });
+
   tests.forEach(function (test) {
     var view = eval(test.view);
 


### PR DESCRIPTION
Address issue #672 by adding `tags` parameter to `render`