### PR TITLE
Cut official support for Node.js 0.8 by not running tests on it anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: node_js
 node_js:
-  - 0.8
   - '0.10'
   - 0.12
   - 4
   - 6
-before_install:
-  - "test $TRAVIS_NODE_VERSION != '0.8' || npm install -g npm@2.x"
 script:
   - npm test
   - "test $TRAVIS_PULL_REQUEST != 'false' || test $TRAVIS_NODE_VERSION != '6' || npm run test-browser"


### PR DESCRIPTION
Primarily because it's very painful to install 3rd party packages in the test phase of our CI runs, because many of them requires at least Node.js 0.10 or even higher.

Therefore getting the test suite to run when using Node.js 0.8 is far from trivial, and the benefit of ensure Node.js 0.8 support these days is not obvious because it should really not be used knowing that it has reached end-of-life a long time ago.

Worth noting there's no breaking changes in this commit to mustache.js's source code, we just don't want to struggle getting our CI to care about it. In other words, it should still be possible to use Node.js 0.8, but we won't care much making sure it keeps working going forward.

Refs latest master build on Travis: https://travis-ci.org/janl/mustache.js/jobs/543123999