### PR TITLE
cli-test: fs.unlink → fs.unlinkSync to fix test failure on Node 10

### DIFF
--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -83,7 +83,7 @@ describe('Mustache CLI', function () {
         assert.equal(stderr, '');
         assert.equal(stdout, '');
         assert.equal(fs.readFileSync(outputFile), expectedOutput);
-        fs.unlink('test/_files/cli_output.txt');
+        fs.unlinkSync('test/_files/cli_output.txt');
         done();
       });
     });


### PR DESCRIPTION
Fixes this failure:

      1) Mustache CLI without partials writes rendered template into the file specified by the third argument:
         Uncaught TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
          at makeCallback (fs.js:136:11)
          at Object.unlink (fs.js:943:14)
          at test/cli-test.js:86:12
          at ChildProcess.exithandler (child_process.js:285:7)
          at maybeClose (internal/child_process.js:982:16)
          at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)