### PR TITLE
Expand context in renderPartial's call to renderTokens.

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -597,7 +597,8 @@
 
     var value = isFunction(partials) ? partials(token[1]) : partials[token[1]];
     if (value != null)
-      return this.renderTokens(this.parse(value, tags), context, partials, value);
+      return this.renderTokens(this.parse(value, tags), context.view[token[1]] ?
+        context.push(context.view[token[1]]) : context, partials, value);
   };
 
   Writer.prototype.unescapedValue = function unescapedValue (token, context) {


### PR DESCRIPTION
Fix for "Partials in nested objects don't work #627"

This fixes the problem I mentioned in #627. Tests ran green.