### PR TITLE
Bugfix for wrong function output in partials with indentation

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -632,7 +632,7 @@
       if (tagIndex == 0 && indentation) {
         indentedValue = this.indentPartial(value, indentation);
       }
-      return this.renderTokens(this.parse(indentedValue, tags), context, partials, value);
+      return this.renderTokens(this.parse(indentedValue, tags), context, partials, indentedValue);
     }
   };
 


### PR DESCRIPTION
This small change fixes the output of functions used in partials with indentation. Bug reports in #712 has shown that the functions output is shifted with the amount of indentation the partial has.

The bug itself is best illustrated in the tests added in https://github.com/janl/mustache.js/pull/713.

Closes #712

/cc @wol-soft @yotammadem 