### PR TITLE
Update readme - Bower deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@ You can get Mustache via [npm](http://npmjs.com).
 ```bash
 $ npm install mustache --save
 ```
-or install with bower:
-
-```bash
-$ bower install --save mustache
-```
 
 ## Command line tool
 


### PR DESCRIPTION
As Bower is deprecated now : https://bower.io/blog/2017/how-to-migrate-away-from-bower/

It does't make sense to mention it in the readme.