### PR TITLE
Allow the CLI to use JavaScript views when the project has ES6 modules enabled.

### DIFF
--- a/bin/mustache
+++ b/bin/mustache
@@ -131,7 +131,8 @@ function isStdin (view) {
 }
 
 function isJsFile (view) {
-  return path.extname(view) === '.js';
+  var extension = path.extname(view);
+  return extension === '.js' || extension === '.cjs';
 }
 
 function wasNotFound (err) {

--- a/test/_files/cli.cjs
+++ b/test/_files/cli.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'LeBron'
+};

--- a/test/_files/cli.js
+++ b/test/_files/cli.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'LeBron'
+};

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -76,6 +76,24 @@ describe('Mustache CLI', function () {
       });
     });
 
+    it('can handle view written in JavaScript with .js suffix', function (done) {
+      exec('bin/mustache test/_files/cli.js test/_files/cli.mustache', function (err, stdout, stderr) {
+        assert.equal(err, null);
+        assert.equal(stderr, '');
+        assert.equal(stdout, expectedOutput);
+        done();
+      });
+    });
+
+    it('can handle view written in JavaScript with .cjs suffix', function (done) {
+      exec('bin/mustache test/_files/cli.cjs test/_files/cli.mustache', function (err, stdout, stderr) {
+        assert.equal(err, null);
+        assert.equal(stderr, '');
+        assert.equal(stdout, expectedOutput);
+        done();
+      });
+    });
+
     it('writes rendered template into the file specified by the third argument', function (done) {
       var outputFile = 'test/_files/cli_output.txt';
       exec('bin/mustache test/_files/cli.json test/_files/cli.mustache ' + outputFile, function (err, stdout, stderr) {

--- a/test/render-helper.js
+++ b/test/render-helper.js
@@ -13,6 +13,7 @@ function getContents (testName, ext) {
 
 function getView (testName) {
   var view = getContents(testName, 'js');
+  if (!view) view = getContents(testName, 'cjs');
   if (!view) throw new Error('Cannot find view for test "' + testName + '"');
   return view;
 }
@@ -34,9 +35,9 @@ if (testToRun) {
   testNames = testToRun.split(',');
 } else {
   testNames = fs.readdirSync(_files).filter(function (file) {
-    return (/\.js$/).test(file);
+    return (/\.c?js$/).test(file);
   }).map(function (file) {
-    return path.basename(file).replace(/\.js$/, '');
+    return path.basename(file).replace(/\.c?js$/, '');
   });
 }
 


### PR DESCRIPTION
Fix #732 by allowing CLI JavaScript views to have the `.cjs` suffix.