### PR TITLE
docs: Fix simple typo, skiped -> skipped

### DIFF
--- a/test/mustache-spec-test.js
+++ b/test/mustache-spec-test.js
@@ -32,7 +32,7 @@ var skipTests = {
   ]
 };
 
-// You can run the skiped tests by setting the NOSKIP environment variable to
+// You can run the skipped tests by setting the NOSKIP environment variable to
 // true (e.g. NOSKIP=true mocha test/mustache-spec-test.js)
 var noSkip = process.env.NOSKIP;
 


### PR DESCRIPTION
There is a small typo in test/mustache-spec-test.js.

Should read `skipped` rather than `skiped`.

