### PR TITLE
Update and simplify package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ qooxdoo.mustache.js
 test/render-test-browser.js
 npm-debug.log
 .DS_Store
-
 test/render-test-browser.js
+.idea/

--- a/package.json
+++ b/package.json
@@ -14,23 +14,18 @@
     "templates",
     "ejs"
   ],
-  "main": "./mustache.js",
+  "main": "mustache.js",
   "bin": {
     "mustache": "./bin/mustache"
   },
   "files": [
-    "mustache.js",
+    "bin/",
     "mustache.mjs",
     "mustache.min.js",
-    "bin",
-    "wrappers",
-    "LICENSE"
+    "wrappers/"
   ],
   "volo": {
     "url": "https://raw.github.com/janl/mustache.js/{version}/mustache.js"
-  },
-  "engines": {
-    "npm": ">=1.4.0"
   },
   "scripts": {
     "build": "rollup mustache.mjs --file mustache.js --format umd --name Mustache --banner '// This file has been generated from mustache.mjs' && uglifyjs mustache.js > mustache.min.js",


### PR DESCRIPTION
Add `.idea/` to `.gitignore`, and a couple of minor updates and simplifications to `package.json`:

- npm _always_ includes `LICENSE`, and the file declared in `main` in the packaged artifact, therefore, it's not necessary to also list them in `files` (reference: https://docs.npmjs.com/files/package.json#files)
- Also removed the engines section which listed a suuuper old version of npm.