### PR TITLE
Updated deno usage test to avoid use of deprecated URL

### DIFF
--- a/test/module-systems/deno-test.ts
+++ b/test/module-systems/deno-test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@v0.51.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.51.0/testing/asserts.ts";
 import mustache from "../../mustache.mjs";
 
 const view = {


### PR DESCRIPTION
As seen from the test run log:

```
$ deno test --allow-net=deno.land test/module-systems/deno-test.ts

Compile file:///home/runner/work/mustache.js/mustache.js/.deno.test.ts
Download deno.land/std@v0.51.0/testing/asserts.ts
Warning std versions prefixed with 'v' were deprecated recently. Please change your import to deno.land/std@0.51.0/testing/asserts.ts (at deno.land/std@v0.51.0/testing/asserts.ts)
error: Uncaught Error: Import 'deno.land/std@v0.51.0/testing/asserts.ts' failed: 404 Not Found
    at unwrapResponse ($deno$/ops/dispatch_json.ts:43:11)
    at Object.sendAsync ($deno$/ops/dispatch_json.ts:98:10)
    at async processImports ($deno$/compiler.ts:736:23)
```