### PR TITLE
Add package.json `exports` field

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -64,9 +64,11 @@ jobs:
           export UNPACK_DESTINATION=$(mktemp -d)
           mv mustache.tgz $UNPACK_DESTINATION
           cp test/module-systems/esm-test.mjs $UNPACK_DESTINATION
+          cp test/module-systems/esm-test-exports.mjs $UNPACK_DESTINATION
           cd $UNPACK_DESTINATION
           npm install mustache.tgz
           node esm-test.mjs
+          node esm-test-exports.mjs
 
   browser-usage:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -25,8 +25,11 @@
     "wrappers/"
   ],
   "exports": {
-    "import": "./mustache.mjs",
-    "require": "./mustache.js"
+    ".": {
+      "import": "./mustache.mjs",
+      "require": "./mustache.js"
+    },
+    "./*": "./*"
   },
   "volo": {
     "url": "https://raw.github.com/janl/mustache.js/{version}/mustache.js"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "mustache.min.js",
     "wrappers/"
   ],
+  "exports": {
+    "import": "./mustache.mjs",
+    "require": "./mustache.js"
+  },
   "volo": {
     "url": "https://raw.github.com/janl/mustache.js/{version}/mustache.js"
   },

--- a/test/module-systems/esm-test-exports.mjs
+++ b/test/module-systems/esm-test-exports.mjs
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import mustache from 'mustache';
+
+const view = {
+  title: 'Joe',
+  calc: () => 2 + 4
+};
+
+assert.strictEqual(
+  mustache.render('{{title}} spends {{calc}}', view),
+  'Joe spends 6'
+);


### PR DESCRIPTION
Adds the new `"exports"` field in `package.json` to define [conditional exports](https://nodejs.org/api/packages.html#packages_conditional_exports) for `mustache.js` (ESM & CJS). This field is used both by Node and bundlers to resolve dependencies. Since there is no `"module"` entrypoint for this package, some bundlers (`rollup` + `@rollup/plugin-node-resolve`) cannot resolve the module export. This is a step towards making both modules discoverable.

### Example

```json
// package.json
{
  "main": "index.js",
  "type": "module",
  "scripts": {
    "build": "rollup -c"
  },
  "dependencies": {
    "@rollup/plugin-node-resolve": "^11.2.0",
    "mustache": "^4.1.0",
    "rollup": "^2.40.0"
  }
}

```

```javascript
import Mustache from 'mustache';

const view = {
  title: "Joe",
  calc: function () {
    return 2 + 4;
  }
};

const output = Mustache.render("{{title}} spends {{calc}}", view);
console.log(output)
```

```javascript
// rollup.config.js
import resolve from '@rollup/plugin-node-resolve';

export default {
  input: 'index.js',
  output: { file: 'bundle.js', format: 'esm' },
  plugins: [ resolve() ]
}
```


```bash
❯ npm run build

> rollup -c


index.js → bundle.js...
(!) `this` has been rewritten to `undefined`
https://rollupjs.org/guide/en/#error-this-is-undefined
node_modules/mustache/mustache.js
4:   typeof define === 'function' && define.amd ? define(factory) :
5:   (global = global || self, global.Mustache = factory());
6: }(this, (function () { 'use strict';
     ^
7:
8:   /*!
[!] Error: 'default' is not exported by node_modules/mustache/mustache.js, imported by index.js
https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module
index.js (1:7)
1: import Mustache from 'mustache';
          ^
2:
3: const view = {
Error: 'default' is not exported by node_modules/mustache/mustache.js, imported by index.js
    at error (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:5279:30)
    at Module.error (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:9996:16)
    at Module.traceVariable (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:10389:29)
    at ModuleScope.findVariable (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:8847:39)
    at MemberExpression.bind (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:6535:49)
    at CallExpression.bind (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:2728:23)
    at CallExpression.bind (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:6730:15)
    at VariableDeclarator.bind (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:2728:23)
    at VariableDeclaration.bind (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:2724:31)
    at Program.bind (/Users/fm813/github/manzt/reference-spec-reader/node_modules/rollup/dist/shared/rollup.js:2724:31)

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ build: `rollup -c`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @ build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/fm813/.npm/_logs/2021-03-03T20_51_56_547Z-debug.log
```