### PR TITLE
globals helpers

### DIFF
--- a/mustache.js
+++ b/mustache.js
@@ -703,7 +703,7 @@ Writer.prototype.invokeGlobalHelper = function invokeGlobalHelper (token, contex
     return view = view[arg[0]];
   }(argsHelper.split(/\.+/g).reverse());
 
-  return mustache.escape(mustache.helpers.get(helperName)(value)) || null;
+  return mustache.escape(mustache.helpers.get(helperName)(value));
 };
 
 Writer.prototype.getConfigTags = function getConfigTags (config) {

--- a/mustache.js
+++ b/mustache.js
@@ -703,7 +703,7 @@ Writer.prototype.invokeGlobalHelper = function invokeGlobalHelper (token, contex
     return view = view[arg[0]];
   }(argsHelper.split(/\.+/g).reverse());
 
-  return mustache.escape(mustache.helpers.get(helperName)(value));
+  return mustache.escape(mustache.helpers[helperName](value));
 };
 
 Writer.prototype.getConfigTags = function getConfigTags (config) {
@@ -728,7 +728,7 @@ Writer.prototype.getConfigEscape = function getConfigEscape (config) {
 };
 
 var mustache = {
-  helpers: new Map(),
+  helpers: {},
   name: 'mustache.js',
   version: '4.2.0',
   tags: [ '{{', '}}' ],
@@ -786,7 +786,7 @@ mustache.globalHelper = function globalHelper (name, helper) {
     return false;
   }
 
-  mustache.helpers.set(name, helper);
+  mustache.helpers[name] = helper;
 };
 
 /**


### PR DESCRIPTION
### Globals Helpers

Globals Helpers is a collection of global methods, unlike Function, each method in this collection will be available in any template rendered by the Mustache instance.

**The globalHelper Method** 

This method allows you to add a global helper to the Globals Helpers collection, the first parameter is the name of the helper, and the second is the method associated with the helper which receives a perameter that is passed from the template to render.

```
Mustache.globalHelper('twoDigits', function (number) {
   return number.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
});
```

**Usage**  
```
let data = {
   number: 1568.3632,
   other: {
      number: 1994.6575
   }
};

//Access the helper using the name with which it was added and tag @
let template = 'The first one {{@twoDigits number}} and the second one {{@twoDigits other.number}}';
$('body').append(Mustache.render(template, data));
```
output

> The first one 1,568.36 and the second one 1,994.66 

_Thanks._



