### PR TITLE
Fix missing semicolon in `test/cli-test.js`

### DIFF
--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -10,7 +10,7 @@ var moduleVersion = require('../package').version;
 
 function changeForOS (command) {
   var requireFlag = !isLegacyNodeVersion ? '--require esm' : '';
-  command = command.replace('bin/mustache', 'node ' + requireFlag + ' bin/mustache')
+  command = command.replace('bin/mustache', 'node ' + requireFlag + ' bin/mustache');
 
   if (process.platform === 'win32') {
     return command


### PR DESCRIPTION
when run `npm test` it shows 

> test\cli-test.js 13:85  error  Missing semicolon  semi