### PR TITLE
Run CommonJS/ESM usage tests on more Node.js versions

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -51,13 +51,17 @@ jobs:
   common-js-usage:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+
     needs: package
     steps:
       - uses: actions/checkout@v1
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node-version }}
       - name: Get package tarball from package step
         uses: actions/download-artifact@v2
         with:
@@ -74,13 +78,17 @@ jobs:
   esm-usage:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [14.x, 15.x]
+
     needs: package
     steps:
       - uses: actions/checkout@v1
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '>=13.2.0'
+          node-version: ${{ matrix.node-version }}
       - name: Get package tarball from package step
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
As it's very interesting to see how the package works for different still maintained/major versions of Node.js, not just 12.x or 13.x as before.

..especially with a recent report of v4.2.0 breaking pre Node.js 14.x projects: https://github.com/janl/mustache.js/issues/775