### PR TITLE
Add newer versions of node to github actions

### DIFF
--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -53,7 +53,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
 
     needs: package
     steps:
@@ -80,7 +80,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 15.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     needs: package
     steps:

--- a/.github/workflows/usage.yml
+++ b/.github/workflows/usage.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: npm install and build
         run: |
           npm install
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: Get build-output from build step
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 20.x
       - run: npm install
       - run: npm run test-lint
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 20.x
       - name: npm install and build
         run: |
           npm install

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There's been quite a few new version of node released since the github actions config was written.
This adds all even versions (Long-term supported ones) to the github actions matrixes up to version 20.
It also uses version 20 for any jobs which run once.

Version 22 of node is also now available, but that seems to break the build, so will need a bit more investigation before adding.